### PR TITLE
feat: allow users to add an API key on the App Config

### DIFF
--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -56,7 +56,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     };
   };
 
-  saveAPIKey = () => {
+  setAPIKey = () => {
     // Gets the value from the API Key textfield,
     // saving it as an application installation parameter
     let keyValue: string = (document.getElementById("APIKey") as HTMLInputElement).value;
@@ -72,6 +72,13 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     }
   };
 
+  getAPIKey = async () => {
+    return this.props.sdk.app.getParameters()
+    .then((response: AppInstallationParameters | null) => {
+      return response?.imgixAPIKey;
+    });
+  };
+
   render() {
     return (
       <Workbench className={css({ margin: '80px' })}>
@@ -82,13 +89,14 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             name="API Key"
             id="APIKey"
             labelText="API Key"
+            value={this.state.parameters?.imgixAPIKey || ""}
             helpText="Access your API key at https://dashboard.imgix.com/api-keys"
             required={true}
           />
           <Button
             type='submit'
             buttonType='positive'
-            onClick={this.saveAPIKey}
+            onClick={this.setAPIKey}
           >
               Save
           </Button>

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -3,7 +3,9 @@ import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { Heading, Form, Workbench, Paragraph, TextField, Button } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
 
-export interface AppInstallationParameters {}
+export interface AppInstallationParameters {
+  imgixAPIKey?: string;
+}
 
 interface ConfigProps {
   sdk: AppExtensionSDK;
@@ -54,6 +56,22 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     };
   };
 
+  saveAPIKey = () => {
+    // Gets the value from the API Key textfield,
+    // saving it as an application installation parameter
+    let keyValue: string = (document.getElementById("APIKey") as HTMLInputElement).value;
+
+    if (keyValue) {
+      const keyParameter: AppInstallationParameters = { imgixAPIKey: keyValue };
+      const updatedState = {
+        parameters: {
+          ...keyParameter
+        }
+      };
+      this.setState(updatedState);
+    }
+  };
+
   render() {
     return (
       <Workbench className={css({ margin: '80px' })}>
@@ -62,7 +80,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           <Paragraph>Welcome to your imgix Contentful app. This is your config page.</Paragraph>
           <TextField
             name="API Key"
-            id="imgixAPI"
+            id="APIKey"
             labelText="API Key"
             helpText="Access your API key at https://dashboard.imgix.com/api-keys"
             required={true}
@@ -70,6 +88,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           <Button
             type='submit'
             buttonType='positive'
+            onClick={this.saveAPIKey}
           >
               Save
           </Button>

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
-import { Heading, Form, Workbench, Paragraph } from '@contentful/forma-36-react-components';
+import { Heading, Form, Workbench, Paragraph, TextField, Button } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
 
 export interface AppInstallationParameters {}
@@ -59,7 +59,20 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       <Workbench className={css({ margin: '80px' })}>
         <Form>
           <Heading>App Config</Heading>
-          <Paragraph>Welcome to your contentful app. This is your config page.</Paragraph>
+          <Paragraph>Welcome to your imgix Contentful app. This is your config page.</Paragraph>
+          <TextField
+            name="API Key"
+            id="imgixAPI"
+            labelText="API Key"
+            helpText="Access your API key at https://dashboard.imgix.com/api-keys"
+            required={true}
+          />
+          <Button
+            type='submit'
+            buttonType='positive'
+          >
+              Save
+          </Button>
         </Form>
       </Workbench>
     );


### PR DESCRIPTION
Adds the installation workflow needed in order to add an imgix API key to a Contentful application space. 

https://user-images.githubusercontent.com/15919091/111363132-e4d91300-864c-11eb-8f17-9ef41a77f9b3.mov

