### PR TITLE
feat: create flow for users to select an enabled imgix source

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -67,6 +67,15 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
+  getImages = async () => {
+    return this.state.imgix.request(`assets/${this.state.selectedSource?.id}`);
+  };
+
+  getImagePaths = async () => {
+    const images = await this.getImages();
+    return images.data.map((image: any) => image.attributes.origin_path);
+  };
+
   setOpen = (isOpen: boolean) => {
     this.setState({ isOpen: isOpen });
   };

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -108,8 +108,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
               <DropdownListItem
                 key={source.id}
                 onClick={() => {
-                  this.setState({ selectedSource: source });
-                  this.setOpen(!this.state.isOpen);
+                  this.setState({ selectedSource: source }, () => {
+                    this.setOpen(false);
+                    this.getImagePaths();
+                  });
                 }}
               >
                 {source.name}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -90,12 +90,22 @@ export default class Dialog extends Component<DialogProps, DialogState> {
               indicateDropdown
               onClick={() => this.setOpen(!this.state.isOpen)}
             >
-              Select a Source
+              {this.state.selectedSource.name || 'Select a Source'}
             </Button>
           }
         >
           <DropdownList>
-            <DropdownListItem>Example item</DropdownListItem>
+            {this.state.allSources.map((source: SourceProps) => (
+              <DropdownListItem
+                key={source.id}
+                onClick={() => {
+                  this.setState({ selectedSource: source });
+                  this.setOpen(!this.state.isOpen);
+                }}
+              >
+                {source.name}
+              </DropdownListItem>
+            ))}
           </DropdownList>
         </Dropdown>
         <br />

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -120,7 +120,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           </DropdownList>
         </Dropdown>
         <br />
-        <Button onClick={() => this.props.sdk.close('Done!')} />
+        <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
       </div>
     );
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -22,9 +22,32 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     });
 
     this.state = {
-      imgix,
+      imgix
     };
   }
+
+  getSources = async (props: DialogProps) => {
+    return await this.state.imgix.request('sources');
+  };
+
+  getSourceIDAndPaths = async (
+    props: DialogProps,
+  ) => {
+    const sources = await this.getSources(props);
+    const enabledSources = sources.data.reduce(
+      (result: any[], source: any) => {
+        if (source.attributes.enabled) {
+          let id = source.id;
+          let name = source.attributes.name;
+          result.push({ id, name });
+        }
+        return result;
+      },
+      [],
+    );
+
+    return enabledSources;
+  };
 
   render() {
     return (

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -10,7 +10,14 @@ interface DialogProps {
 
 interface DialogState {
   imgix: any; // TODO - replace with class type
+  allSources: Array<SourceProps>;
+  selectedSource: Partial<SourceProps>;
 }
+
+type SourceProps = {
+  id: string;
+  name: string;
+};
 
 export default class Dialog extends Component<DialogProps, DialogState> {
   constructor(props: DialogProps) {
@@ -22,7 +29,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     });
 
     this.state = {
-      imgix
+      imgix,
+      allSources: [],
+      selectedSource: {},
     };
   }
 
@@ -32,10 +41,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   getSourceIDAndPaths = async (
     props: DialogProps,
-  ) => {
+  ): Promise<Array<SourceProps>> => {
     const sources = await this.getSources(props);
     const enabledSources = sources.data.reduce(
-      (result: any[], source: any) => {
+      (result: SourceProps[], source: any) => {
         if (source.attributes.enabled) {
           let id = source.id;
           let name = source.attributes.name;
@@ -48,6 +57,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
     return enabledSources;
   };
+
+  async componentDidMount() {
+    const sources = await this.getSourceIDAndPaths(this.props);
+    this.setState({ allSources: sources });
+  }
 
   render() {
     return (

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,5 +1,11 @@
 import React, { Component } from 'react';
-import { Button, Paragraph } from '@contentful/forma-36-react-components';
+import {
+  Button,
+  Paragraph,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 // @ts-ignore - TODO add .d.ts file
 import ImgixApi from 'imgix-management-js';
@@ -23,7 +29,8 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   constructor(props: DialogProps) {
     super(props);
 
-    const apiKey = (props as any).sdk?.parameters.installation.imgixAPIKey || "";
+    const apiKey =
+      (props as any).sdk?.parameters.installation.imgixAPIKey || '';
     const imgix = new ImgixApi({
       apiKey,
     });
@@ -67,6 +74,25 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return (
       <div>
         <Paragraph>Hello Dialog Component</Paragraph>
+        <Dropdown
+          isOpen={false}
+          onClose={() => {}}
+          toggleElement={
+            <Button
+              size="small"
+              buttonType="muted"
+              indicateDropdown
+              onClick={() => {}}
+            >
+              Select a Source
+            </Button>
+          }
+        >
+          <DropdownList>
+            <DropdownListItem>Example item</DropdownListItem>
+          </DropdownList>
+        </Dropdown>
+        <br />
         <Button onClick={() => this.props.sdk.close('Done!')} />
       </div>
     );

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -16,6 +16,7 @@ interface DialogProps {
 
 interface DialogState {
   imgix: any; // TODO - replace with class type
+  isOpen: boolean;
   allSources: Array<SourceProps>;
   selectedSource: Partial<SourceProps>;
 }
@@ -37,6 +38,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
     this.state = {
       imgix,
+      isOpen: false,
       allSources: [],
       selectedSource: {},
     };
@@ -65,6 +67,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
+  setOpen = (isOpen: boolean) => {
+    this.setState({ isOpen: isOpen });
+  };
+
   async componentDidMount() {
     const sources = await this.getSourceIDAndPaths(this.props);
     this.setState({ allSources: sources });
@@ -75,14 +81,14 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       <div>
         <Paragraph>Hello Dialog Component</Paragraph>
         <Dropdown
-          isOpen={false}
-          onClose={() => {}}
+          isOpen={this.state.isOpen}
+          onClose={() => this.setOpen(false)}
           toggleElement={
             <Button
               size="small"
               buttonType="muted"
               indicateDropdown
-              onClick={() => {}}
+              onClick={() => this.setOpen(!this.state.isOpen)}
             >
               Select a Source
             </Button>

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -18,7 +18,9 @@ const Field = (props: FieldProps) => {
         onClick={() => {
           props.sdk.dialogs.openCurrentApp({ width: 1000, minHeight: 2000 });
         }}
-      />
+      >
+        Select an Image
+      </Button>
     </div>
   );
 };

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -16,8 +16,7 @@ const Field = (props: FieldProps) => {
       <Paragraph>Hello Entry Field Component</Paragraph>
       <Button
         onClick={() => {
-          props.sdk.dialogs
-            .openCurrentApp({ width: 1000, minHeight: 2000 })
+          props.sdk.dialogs.openCurrentApp({ width: 1000, minHeight: 2000 });
         }}
       />
     </div>


### PR DESCRIPTION
This PR adds a dropdown menu in the field dialog populated with all active sources from the account corresponding to the API key provided in #15. It also includes some helper functions for parsing out the image paths, which will later be used to render images from each source.

https://user-images.githubusercontent.com/15919091/113606851-6513e800-95fd-11eb-94b1-154c17c0a200.mov

