### PR TITLE
feat: render images via the `Gallery` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "imgix-management-js": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "react-imgix": "^9.0.3",
+        "react-imgix": "^9.1.1",
         "react-scripts": "4.0.3",
         "typescript": "^4.1.3"
       },
@@ -1824,6 +1824,15 @@
       "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dependencies": {
         "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "node_modules/@imgix/js-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.1.3.tgz",
+      "integrity": "sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==",
+      "dependencies": {
+        "js-base64": "~2.6.0",
+        "md5": "^2.2.1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -4923,6 +4932,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -5637,6 +5654,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-browserify": {
@@ -11608,6 +11633,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -14915,19 +14950,19 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-imgix": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/react-imgix/-/react-imgix-9.0.3.tgz",
-      "integrity": "sha512-cSK3z7njg8eiWwEx+XhGUcwmjUMSe/OvzedyLhmuEXb9ASMjqJM8c6vegmrJ6qXHElWw1UOH7BwfoQn7IXiYVw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-imgix/-/react-imgix-9.1.1.tgz",
+      "integrity": "sha512-WeUjRGv5jriItS0Fy/z3KoYUcOjMfiY8xJBVR8di4xjpIXXxl/s/qnqCqdl6N6c0LgxDaF+CJoA1HR5DNBxQJA==",
       "dependencies": {
-        "js-base64": "~2.6.0",
+        "@imgix/js-core": "^3.1.3",
         "react-measure": "^2.3.0",
         "shallowequal": "^1.1.0",
         "warning": "^4.0.1"
       },
       "peerDependencies": {
         "prop-types": ">=15.5.6",
-        "react": ">=15",
-        "react-dom": ">=15"
+        "react": "15.x || 16.x || 17.x",
+        "react-dom": "15.x || 16.x || 17.x"
       }
     },
     "node_modules/react-is": {
@@ -22029,6 +22064,15 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@imgix/js-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.1.3.tgz",
+      "integrity": "sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==",
+      "requires": {
+        "js-base64": "~2.6.0",
+        "md5": "^2.2.1"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -24458,6 +24502,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -25056,6 +25105,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -29699,6 +29753,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -32344,11 +32408,11 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-imgix": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/react-imgix/-/react-imgix-9.0.3.tgz",
-      "integrity": "sha512-cSK3z7njg8eiWwEx+XhGUcwmjUMSe/OvzedyLhmuEXb9ASMjqJM8c6vegmrJ6qXHElWw1UOH7BwfoQn7IXiYVw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-imgix/-/react-imgix-9.1.1.tgz",
+      "integrity": "sha512-WeUjRGv5jriItS0Fy/z3KoYUcOjMfiY8xJBVR8di4xjpIXXxl/s/qnqCqdl6N6c0LgxDaF+CJoA1HR5DNBxQJA==",
       "requires": {
-        "js-base64": "~2.6.0",
+        "@imgix/js-core": "^3.1.3",
         "react-measure": "^2.3.0",
         "shallowequal": "^1.1.0",
         "warning": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "imgix-management-js": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-imgix": "^9.0.3",
+    "react-imgix": "^9.1.1",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.3"
   },

--- a/src/components/Dialog.spec.tsx
+++ b/src/components/Dialog.spec.tsx
@@ -5,14 +5,14 @@ import { render } from '@testing-library/react';
 describe('Dialog component', () => {
   it('Component text exists', () => {
     const mockSdk: any = {
-        parameters: {
-          installation: {
-            imgixAPIKey: 'test_key_123'
-          }
-        }
+      parameters: {
+        installation: {
+          imgixAPIKey: 'test_key_123',
+        },
+      },
     };
 
-    const { getByText } = render(<Dialog sdk={mockSdk}/>);
+    const { getByText } = render(<Dialog sdk={mockSdk} />);
     expect(getByText('Hello Dialog Component')).toBeInTheDocument();
   });
 });

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -21,7 +21,7 @@ interface DialogState {
   selectedSource: Partial<SourceProps>;
 }
 
-type SourceProps = {
+export type SourceProps = {
   id: string;
   name: string;
   domain: string;

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -9,6 +9,7 @@ import {
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { AppInstallationParameters } from './ConfigScreen';
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import Gallery from './Gallery';
 
 interface DialogProps {
   sdk: DialogExtensionSDK;
@@ -136,6 +137,14 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         </Dropdown>
         <br />
         <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
+        <br />
+        <br />
+        {this.state.selectedSource && (
+          <Gallery
+            selectedSource={this.state.selectedSource}
+            imgix={this.state.imgix}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -92,44 +92,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
-  getImages = async () => {
-    return await this.state.imgix.request(
-      `assets/${this.state.selectedSource?.id}`,
-    );
-  };
-
-  getImagePaths = async () => {
-    let images,
-      allOriginPaths: string[] = [];
-
-    try {
-      images = await this.getImages();
-    } catch (error) {
-      // APIError will emit more helpful data for debugging
-      if (error instanceof APIError) {
-        console.error(error.toString());
-      } else {
-        console.error(error);
-      }
-      return allOriginPaths;
-    }
-
-    /*
-     * Resolved requests can either return an array of objects or a single
-     * object via the `data` top-level field. When parsing all enabled sources,
-     * both possibilities must be accounted for.
-     */
-    const imagesArray = Array.isArray(images.data)
-      ? images.data
-      : [images.data];
-    imagesArray.map((image: any) =>
-      // TODO: add more explicit types for image
-      allOriginPaths.push(image.attributes.origin_path),
-    );
-
-    return allOriginPaths;
-  };
-
   setOpen = (isOpen: boolean) => {
     this.setState({ isOpen: isOpen });
   };
@@ -164,7 +126,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                 onClick={() => {
                   this.setState({ selectedSource: source }, async () => {
                     this.setOpen(false);
-                    await this.getImagePaths();
                   });
                 }}
               >

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,0 +1,11 @@
+import { Component } from 'react';
+
+export default class Gallery extends Component {
+
+  render() {
+    return (
+      <div className="gallery">
+      </div>
+    );
+  }
+}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -60,6 +60,20 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     return allOriginPaths;
   };
 
+  /*
+   * Constructs an array of imgix image URL from the selected source in the
+   * application Dialog component
+   */
+  constructUrl(images: string[]) {
+    const scheme = 'https://';
+    const domain = this.props.selectedSource.name;
+    const imgixDomain = '.imgix.net';
+
+    const urls = images.map(
+      (path: string) => scheme + domain + imgixDomain + path,
+    );
+    return urls;
+  }
   render() {
     return (
       <div className="gallery">

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,4 +1,4 @@
-import ImgixAPI from 'imgix-management-js';
+import ImgixAPI, { APIError } from 'imgix-management-js';
 import { Component } from 'react';
 import { SourceProps } from './Dialog';
 
@@ -22,6 +22,43 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     };
   }
 
+  getImages = async () => {
+    return await this.state.imgix.request(
+      `assets/${this.props.selectedSource?.id}`,
+    );
+  };
+
+  getImagePaths = async () => {
+    let images,
+      allOriginPaths: string[] = [];
+
+    try {
+      images = await this.getImages();
+    } catch (error) {
+      // APIError will emit more helpful data for debugging
+      if (error instanceof APIError) {
+        console.error(error.toString());
+      } else {
+        console.error(error);
+      }
+      return allOriginPaths;
+    }
+
+    /*
+     * Resolved requests can either return an array of objects or a single
+     * object via the `data` top-level field. When parsing all enabled sources,
+     * both possibilities must be accounted for.
+     */
+    const imagesArray = Array.isArray(images.data)
+      ? images.data
+      : [images.data];
+    imagesArray.map((image: any) =>
+      // TODO: add more explicit types for image
+      allOriginPaths.push(image.attributes.origin_path),
+    );
+
+    return allOriginPaths;
+  };
 
   render() {
     return (

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -9,7 +9,6 @@ interface GalleryProps {
 }
 
 interface GalleryState {
-  imgix: ImgixAPI;
   fullUrls: Array<string>;
 }
 
@@ -18,13 +17,12 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     super(props);
 
     this.state = {
-      imgix: props.imgix,
       fullUrls: [],
     };
   }
 
   getImages = async () => {
-    return await this.state.imgix.request(
+    return await this.props.imgix.request(
       `assets/${this.props.selectedSource?.id}`,
     );
   };

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,5 +1,6 @@
 import ImgixAPI, { APIError } from 'imgix-management-js';
 import { Component } from 'react';
+import Imgix from 'react-imgix';
 import { SourceProps } from './Dialog';
 
 interface GalleryProps {
@@ -86,6 +87,14 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
   render() {
     return (
       <div className="gallery">
+        <ul>
+          {this.state.fullUrls.length > 0 &&
+            this.state.fullUrls.map((url: string) => (
+              <li>
+                <Imgix src={url} width={100} height={100} />
+              </li>
+            ))}
+        </ul>
       </div>
     );
   }

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,6 +1,18 @@
+import ImgixAPI from 'imgix-management-js';
 import { Component } from 'react';
+import { SourceProps } from './Dialog';
 
-export default class Gallery extends Component {
+interface GalleryProps {
+  selectedSource: Partial<SourceProps>;
+  imgix: ImgixAPI;
+}
+
+interface GalleryState {
+  imgix: ImgixAPI;
+  fullUrls: Array<string>;
+}
+
+export default class Gallery extends Component<GalleryProps, GalleryState> {
 
   render() {
     return (

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -74,6 +74,15 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     );
     return urls;
   }
+
+  async componentDidUpdate(prevProps: GalleryProps) {
+    if (this.props.selectedSource !== prevProps.selectedSource) {
+      const images = await this.getImagePaths();
+      const fullUrls = this.constructUrl(images);
+      this.setState({ fullUrls });
+    }
+  }
+
   render() {
     return (
       <div className="gallery">

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -13,6 +13,15 @@ interface GalleryState {
 }
 
 export default class Gallery extends Component<GalleryProps, GalleryState> {
+  constructor(props: GalleryProps) {
+    super(props);
+
+    this.state = {
+      imgix: props.imgix,
+      fullUrls: [],
+    };
+  }
+
 
   render() {
     return (


### PR DESCRIPTION
This PR introduces a new `Gallery` component that is responsible for rendering images based on the Source selected by a user (as seen in #16). This component not only keeps the rendering logic separate from the `Dialog` component but also defers making specific API requests until the Source ID is known. In terms of scope, this PR is mainly concerned with correctly requesting/rendering the images. While the component styling is severely lacking, it will get more attention in a separate PR.


https://user-images.githubusercontent.com/15919091/117900467-16054680-b27e-11eb-8d6d-892d2d5f4d63.mov

