### PR TITLE
fix: conditionally render Gallery only if selectedSource.id is defined

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -139,7 +139,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
         <br />
         <br />
-        {this.state.selectedSource && (
+        {this.state.selectedSource.id && (
           <Gallery
             selectedSource={this.state.selectedSource}
             imgix={this.state.imgix}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -10,6 +10,7 @@ interface GalleryProps {
 
 interface GalleryState {
   fullUrls: Array<string>;
+  currentSourceId: string | undefined;
 }
 
 export default class Gallery extends Component<GalleryProps, GalleryState> {
@@ -18,6 +19,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
 
     this.state = {
       fullUrls: [],
+      currentSourceId: undefined,
     };
   }
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -76,11 +76,12 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     return urls;
   }
 
-  async componentDidUpdate(prevProps: GalleryProps) {
-    if (this.props.selectedSource !== prevProps.selectedSource) {
+  async componentDidUpdate() {
+    if (this.props.selectedSource.id !== this.state.currentSourceId) {
       const images = await this.getImagePaths();
       const fullUrls = this.constructUrl(images);
-      this.setState({ fullUrls });
+      const currentSourceId = this.props.selectedSource.id;
+      this.setState({ fullUrls, currentSourceId });
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in which the `Gallery` component was being erroneously rendered although there was no Source selected via the parent `Dialog` component. Conditional rendering of `Gallery` evaluated `this.state.selectedSource` for a truthy value, assuming that the empty state (`{}`) would result in `false`, which it did not (thanks JavaScript). Now, the condition evaluates if a Source ID is selected/defined, which is much more explicit. This PR also makes a performance improvement by preventing repeat requests for the same asset endpoint if the selected Source ID has not changed.