### PR TITLE
fix: don't copy props into state

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -139,10 +139,13 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
         <br />
         <br />
-        <Gallery
-          selectedSource={this.state.selectedSource}
-          imgix={this.state.imgix}
-        />
+        {
+          this.state.selectedSource?.id &&
+          <Gallery
+            selectedSource={this.state.selectedSource}
+            imgix={this.state.imgix}
+          />
+        }
       </div>
     );
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -93,8 +93,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
-  setOpen = (isOpen: boolean) => {
-    this.setState({ isOpen: isOpen });
+  setOpen = (isOpen: boolean, selectedSource?: SourceProps) => {
+    if (selectedSource) {
+      this.setState({ isOpen, selectedSource });
+    } else {
+      this.setState({ isOpen });
+    }
   };
 
   async componentDidMount() {
@@ -124,11 +128,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             {this.state.allSources.map((source: SourceProps) => (
               <DropdownListItem
                 key={source.id}
-                onClick={() => {
-                  this.setState({ selectedSource: source }, async () => {
-                    this.setOpen(false);
-                  });
-                }}
+                onClick={() => this.setOpen(false, source)}
               >
                 {source.name}
               </DropdownListItem>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -139,12 +139,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
         <br />
         <br />
-        {this.state.selectedSource.id && (
-          <Gallery
-            selectedSource={this.state.selectedSource}
-            imgix={this.state.imgix}
-          />
-        )}
+        <Gallery
+          selectedSource={this.state.selectedSource}
+          imgix={this.state.imgix}
+        />
       </div>
     );
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -139,13 +139,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         <Button onClick={() => this.props.sdk.close('Done!')}>Done</Button>
         <br />
         <br />
-        {
-          this.state.selectedSource?.id &&
+        {this.state.selectedSource?.id && (
           <Gallery
             selectedSource={this.state.selectedSource}
             imgix={this.state.imgix}
           />
-        }
+        )}
       </div>
     );
   }

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -17,7 +17,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     super(props);
 
     this.state = {
-      fullUrls: []
+      fullUrls: [],
     };
   }
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -84,6 +84,10 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     this.setState({ fullUrls });
   }
 
+  async componentDidMount() {
+    this.renderImages();
+  }
+
   async componentDidUpdate(prevProps: GalleryProps) {
     if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
       const images = await this.getImagePaths();

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -90,9 +90,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
 
   async componentDidUpdate(prevProps: GalleryProps) {
     if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
-      const images = await this.getImagePaths();
-      const fullUrls = this.constructUrl(images);
-      this.setState({ fullUrls });
+      this.renderImages();
     }
   }
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -74,6 +74,16 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     return urls;
   }
 
+  /*
+   * Requests and constructs fully-qualified image URLs, saving the results to
+   * state
+   */
+  async renderImages() {
+    const images = await this.getImagePaths();
+    const fullUrls = this.constructUrl(images);
+    this.setState({ fullUrls });
+  }
+
   async componentDidUpdate(prevProps: GalleryProps) {
     if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
       const images = await this.getImagePaths();

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -10,7 +10,6 @@ interface GalleryProps {
 
 interface GalleryState {
   fullUrls: Array<string>;
-  currentSourceId: string | undefined;
 }
 
 export default class Gallery extends Component<GalleryProps, GalleryState> {
@@ -18,8 +17,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     super(props);
 
     this.state = {
-      fullUrls: [],
-      currentSourceId: undefined,
+      fullUrls: []
     };
   }
 
@@ -76,12 +74,11 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     return urls;
   }
 
-  async componentDidUpdate() {
-    if (this.props.selectedSource.id !== this.state.currentSourceId) {
+  async componentDidUpdate(prevProps: GalleryProps) {
+    if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
       const images = await this.getImagePaths();
       const fullUrls = this.constructUrl(images);
-      const currentSourceId = this.props.selectedSource.id;
-      this.setState({ fullUrls, currentSourceId });
+      this.setState({ fullUrls });
     }
   }
 


### PR DESCRIPTION
This PR primarily addresses the feedback left in [this comment](https://github.com/imgix/contentful/pull/26#discussion_r635926290). It also takes addresses some other component weirdness related to multiple re-renders by combining multiple calls to `setState`. Finally, it defines a `componentDidMount` hook in the `Gallery` component to handle its first render cycle, while `componentDidUpdate` will handle all subsequent ones. 

Thanks again for the help @frederickfogerty 👍 