### PR TITLE
feat(Galley): display images in a grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "prettier --write '{src,test}/**/*.tsx'"
+    "lint": "prettier --write '{src,test}/**/*.{tsx,css}'"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -16,7 +16,11 @@ const Field = (props: FieldProps) => {
       <Paragraph>Hello Entry Field Component</Paragraph>
       <Button
         onClick={() => {
-          props.sdk.dialogs.openCurrentApp({ width: 1000, minHeight: 2000 });
+          props.sdk.dialogs.openCurrentApp({
+            width: 'fullWidth',
+            minHeight: 1000,
+            position: 'top',
+          });
         }}
       >
         Select an Image

--- a/src/components/Gallery.css
+++ b/src/components/Gallery.css
@@ -1,0 +1,22 @@
+.column {
+  float: left;
+  padding: 10px;
+  width: calc(12.5% - 20px);
+}
+
+.column img {
+  opacity: 0.8;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.column img:hover {
+  opacity: 1;
+}
+
+.row:after {
+  content: '';
+  display: table;
+  clear: both;
+}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -97,15 +97,22 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
 
   render() {
     return (
-      <div className="gallery">
-        <ul>
-          {this.state.fullUrls.length > 0 &&
-            this.state.fullUrls.map((url: string) => (
-              <li>
-                <Imgix src={url} width={100} height={100} />
-              </li>
-            ))}
-        </ul>
+      <div className="row">
+        {this.state.fullUrls.length > 0 &&
+          this.state.fullUrls.map((url: string) => (
+            <div className="column">
+              <Imgix
+                src={url}
+                width={100}
+                height={100}
+                imgixParams={{
+                  fit: 'crop',
+                  crop: 'entropy',
+                }}
+                sizes="(min-width: 480px) calc(12.5vw - 20px)"
+              />
+            </div>
+          ))}
       </div>
     );
   }

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -2,6 +2,7 @@ import ImgixAPI, { APIError } from 'imgix-management-js';
 import { Component } from 'react';
 import Imgix from 'react-imgix';
 import { SourceProps } from './Dialog';
+import './Gallery.css';
 
 interface GalleryProps {
   selectedSource: Partial<SourceProps>;


### PR DESCRIPTION
This PR displays images in a 3x8 grid format, as opposed to the vertical list they are currently displayed in. The request for this format came from the design team, but may still be subject to change upon further review.


https://user-images.githubusercontent.com/15919091/122844873-6a590880-d2b7-11eb-9ae5-c2fe93a95050.mov

