### PR TITLE
feat(Field): allow users to select an image via the Dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "imgix-contentful",
       "version": "0.1.0",
       "dependencies": {
         "@contentful/field-editor-single-line": "^0.14.0",
@@ -25,7 +24,7 @@
         "imgix-management-js": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "react-imgix": "^9.1.1",
+        "react-imgix": "^9.2.0",
         "react-scripts": "4.0.3",
         "typescript": "^4.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "imgix-management-js": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-imgix": "^9.1.1",
+    "react-imgix": "^9.2.0",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.3"
   },

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -36,7 +36,8 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   async componentDidMount() {
     // Get current parameters of the app.
     // If the app is not installed yet, `parameters` will be `null`.
-    const parameters: AppInstallationParameters | null = await this.props.sdk.app.getParameters();
+    const parameters: AppInstallationParameters | null =
+      await this.props.sdk.app.getParameters();
 
     this.setState(parameters ? { parameters } : this.state, () => {
       // Once preparation has finished, call `setReady` to hide
@@ -66,9 +67,9 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   setAPIKey = () => {
     // Gets the value from the API Key textfield,
     // saving it as an application installation parameter
-    let keyValue: string = (document.getElementById(
-      'APIKey',
-    ) as HTMLInputElement).value;
+    let keyValue: string = (
+      document.getElementById('APIKey') as HTMLInputElement
+    ).value;
 
     if (keyValue) {
       const keyParameter: AppInstallationParameters = { imgixAPIKey: keyValue };

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import {
   Button,
   Paragraph,
@@ -143,6 +143,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           <Gallery
             selectedSource={this.state.selectedSource}
             imgix={this.state.imgix}
+            sdk={this.props.sdk}
           />
         )}
       </div>

--- a/src/components/Field.spec.tsx
+++ b/src/components/Field.spec.tsx
@@ -4,8 +4,14 @@ import { render } from '@testing-library/react';
 
 describe('Field component', () => {
   it('Component text exists', () => {
-    const { getByText } = render(<Field />);
+    const mockSdk: any = {
+      field: {
+        getValue: () => {}
+      },
+    };
 
-    expect(getByText('Hello Entry Field Component')).toBeInTheDocument();
+    const { getByText } = render(<Field sdk={mockSdk} />);
+
+    expect(getByText('Select an Image')).toBeInTheDocument();
   });
 });

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -11,6 +11,8 @@ interface FieldState {
 }
 
 export default class Field extends Component<FieldProps, FieldState> {
+  constructor(props: FieldProps) {
+    super(props);
 
   return (
     <div>
@@ -30,4 +32,5 @@ export default class Field extends Component<FieldProps, FieldState> {
   );
 };
 
-export default Field;
+  }
+

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -61,7 +61,9 @@ export default class Field extends Component<FieldProps, FieldState> {
                 position: 'top',
               })
               .then((image) =>
-                this.setState({ image }),
+                this.setState({ image }, () =>
+                  this.props.sdk.field.setValue(image),
+                ),
               );
           }}
         >

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -15,24 +15,11 @@ export default class Field extends Component<FieldProps, FieldState> {
   constructor(props: FieldProps) {
     super(props);
 
-  return (
-    <div>
-      <Paragraph>Hello Entry Field Component</Paragraph>
-      <Button
-        onClick={() => {
-          props.sdk.dialogs.openCurrentApp({
-            width: 'fullWidth',
-            minHeight: 1000,
-            position: 'top',
-          });
-        }}
-      >
-        Select an Image
-      </Button>
-    </div>
-  );
-};
+    const storedValue = this.props.sdk.field.getValue();
 
+    this.state = {
+      image: storedValue || '',
+    };
   }
 
   render() {

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -34,3 +34,25 @@ export default class Field extends Component<FieldProps, FieldState> {
 
   }
 
+  render() {
+    return (
+      <div>
+        <Button
+          onClick={() => {
+            this.props.sdk.dialogs
+              .openCurrentApp({
+                width: 'fullWidth',
+                minHeight: 1000,
+                position: 'top',
+              })
+              .then((image) =>
+                this.setState({ image }),
+              );
+          }}
+        >
+          Select an Image
+        </Button>
+      </div>
+    );
+  }
+}

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { Button } from '@contentful/forma-36-react-components';
 import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
+import Imgix from 'react-imgix';
 
 interface FieldProps {
   sdk: FieldExtensionSDK;
@@ -37,6 +38,20 @@ export default class Field extends Component<FieldProps, FieldState> {
   render() {
     return (
       <div>
+        {this.state.image && (
+          <div>
+            <Imgix
+              width={100}
+              height={100}
+              src={this.state.image}
+              imgixParams={{
+                auto: 'format',
+                fit: 'crop',
+                crop: 'entropy',
+              }}
+            />
+          </div>
+        )}
         <Button
           onClick={() => {
             this.props.sdk.dialogs

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import { Button, Paragraph } from '@contentful/forma-36-react-components';
+import { Component } from 'react';
+import { Button } from '@contentful/forma-36-react-components';
 import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
 
 interface FieldProps {
   sdk: FieldExtensionSDK;
 }
 
-const Field = (props: FieldProps) => {
-  // If you only want to extend Contentful's default editing experience
-  // reuse Contentful's editor components
-  // -> https://www.contentful.com/developers/docs/extensibility/field-editors/
+interface FieldState {
+  image: string;
+}
+
+export default class Field extends Component<FieldProps, FieldState> {
 
   return (
     <div>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -2,11 +2,13 @@ import ImgixAPI, { APIError } from 'imgix-management-js';
 import { Component } from 'react';
 import Imgix from 'react-imgix';
 import { SourceProps } from './Dialog';
+import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import './Gallery.css';
 
 interface GalleryProps {
   selectedSource: Partial<SourceProps>;
   imgix: ImgixAPI;
+  sdk: DialogExtensionSDK;
 }
 
 interface GalleryState {
@@ -106,10 +108,14 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
                 width={100}
                 height={100}
                 imgixParams={{
+                  auto: 'format',
                   fit: 'crop',
                   crop: 'entropy',
                 }}
                 sizes="(min-width: 480px) calc(12.5vw - 20px)"
+                htmlAttributes={{
+                  onClick: () => this.props.sdk.close(url),
+                }}
               />
             </div>
           ))}


### PR DESCRIPTION
This PR adds functionality to allow users to select an image (via `onClick` handler), which then saves the image's URL to the parent Field value. This ultimately results in a (stored) image URL that is returned by the Contentful API when requesting the content instance.

https://user-images.githubusercontent.com/15919091/122844966-93799900-d2b7-11eb-8216-6827fcce279d.mov


Note: the specific interaction of "choosing" an image is still subject to change pending feedback from the Design team.