### PR TITLE
feat(config): add onChange handler to TextField

### DIFF
--- a/src/components/ConfigScreen.css
+++ b/src/components/ConfigScreen.css
@@ -7,3 +7,17 @@
   display: block;
   color: #606c7c;
 }
+
+.flex-container {
+  display: flex;
+}
+
+.flex-child {
+  flex: 20 0 100%;
+}
+
+.icon {
+  flex: 2;
+  margin-top: 10%;
+  margin-left: 10px;
+}

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component, ChangeEvent } from 'react';
 import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
 import {
   Heading,
@@ -65,22 +65,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     };
   };
 
-  setAPIKey = () => {
-    // Gets the value from the API Key textfield,
-    // saving it as an application installation parameter
-    let keyValue: string = (
-      document.getElementById('APIKey') as HTMLInputElement
-    ).value;
-
-    if (keyValue) {
-      const keyParameter: AppInstallationParameters = { imgixAPIKey: keyValue };
-      const updatedState = {
-        parameters: {
-          ...keyParameter,
-        },
-      };
-      this.setState(updatedState);
-    }
+  handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    this.setState({
+      parameters: {
+        imgixAPIKey: e.target.value,
+      },
+    });
   };
 
   getAPIKey = async () => {
@@ -105,10 +95,10 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               id="APIKey"
               labelText="API Key"
               value={this.state.parameters?.imgixAPIKey || ''}
-              required={true}
               textInputProps={{
                 type: 'password',
               }}
+              onChange={this.handleChange}
             />
             <p className="ix-helper-text">
               Access your API key at{' '}

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -15,6 +15,7 @@ import ImgixAPI from 'imgix-management-js';
 
 export interface AppInstallationParameters {
   imgixAPIKey?: string;
+  successfullyVerified?: boolean;
 }
 
 interface ConfigProps {
@@ -80,11 +81,16 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       apiKey: this.state.parameters.imgixAPIKey || '',
     });
 
+    let updatedInstallationParameters: AppInstallationParameters = {
+      ...this.state.parameters,
+    };
+
     try {
       await imgix.request('sources');
       Notification.success('Your API Key was successfully confirmed.', {
         duration: 3000,
       });
+      updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",
@@ -92,11 +98,26 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           duration: 3000,
           },
       );
+      updatedInstallationParameters.successfullyVerified = false;
+    } finally {
+      this.setState({
+        parameters: updatedInstallationParameters,
+      });
     }
   };
 
   onClick = async () => {
+    if (this.state.parameters.imgixAPIKey === '') {
+      let updatedInstallationParameters: AppInstallationParameters = {
+        ...this.state.parameters,
+      };
+      updatedInstallationParameters.successfullyVerified = false;
+      this.setState({
+        parameters: updatedInstallationParameters,
+      });
+    } else {
       await this.verifyAPIKey();
+    }
   };
 
   getAPIKey = async () => {

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -73,6 +73,13 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     });
   };
 
+  verifyAPIKey = async () => {
+  };
+
+  onClick = async () => {
+      await this.verifyAPIKey();
+  };
+
   getAPIKey = async () => {
     return this.props.sdk.app
       .getParameters()
@@ -111,8 +118,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               </a>
             </p>
           </div>
-          <Button type="submit" buttonType="positive" onClick={this.setAPIKey}>
-            Save
+          <Button
+            type="submit"
+            buttonType="positive"
+            onClick={this.onClick}
+          >
+            Verify
           </Button>
         </Form>
       </Workbench>

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -7,6 +7,7 @@ import {
   Paragraph,
   TextField,
   Notification,
+  Icon,
   Button,
 } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
@@ -147,6 +148,9 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               }}
               onChange={this.handleChange}
             />
+            {this.state.parameters.successfullyVerified && (
+                <Icon icon="CheckCircle" size="tiny" color="positive" />
+            )}
             <p className="ix-helper-text">
               Access your API key at{' '}
               <a

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -24,13 +24,17 @@ interface ConfigProps {
 }
 
 interface ConfigState {
+  isButtonLoading?: boolean;
   parameters: AppInstallationParameters;
 }
 
 export default class Config extends Component<ConfigProps, ConfigState> {
   constructor(props: ConfigProps) {
     super(props);
-    this.state = { parameters: {} };
+    this.state = {
+      isButtonLoading: false,
+      parameters: {},
+    };
 
     // `onConfigure` allows to configure a callback to be
     // invoked when a user attempts to install the app or update
@@ -78,6 +82,8 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   };
 
   verifyAPIKey = async () => {
+    this.setState({ isButtonLoading: true });
+
     const imgix = new ImgixAPI({
       apiKey: this.state.parameters.imgixAPIKey || '',
     });
@@ -102,6 +108,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       updatedInstallationParameters.successfullyVerified = false;
     } finally {
       this.setState({
+        isButtonLoading: false,
         parameters: updatedInstallationParameters,
       });
     }
@@ -173,6 +180,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             type="submit"
             buttonType="positive"
             onClick={this.onClick}
+            loading={this.state.isButtonLoading}
           >
             Verify
           </Button>

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -106,7 +106,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         "We couldn't verify this API Key. Confirm your details and try again.",
         {
           duration: 3000,
-          },
+        },
       );
       updatedInstallationParameters.successfullyVerified = false;
     } finally {

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -25,6 +25,7 @@ interface ConfigProps {
 
 interface ConfigState {
   isButtonLoading?: boolean;
+  validationMessage?: string;
   parameters: AppInstallationParameters;
 }
 
@@ -33,6 +34,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     super(props);
     this.state = {
       isButtonLoading: false,
+      validationMessage: '',
       parameters: {},
     };
 
@@ -108,6 +110,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       updatedInstallationParameters.successfullyVerified = false;
     } finally {
       this.setState({
+        validationMessage: '',
         isButtonLoading: false,
         parameters: updatedInstallationParameters,
       });
@@ -121,6 +124,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       };
       updatedInstallationParameters.successfullyVerified = false;
       this.setState({
+        validationMessage: 'Please input your API Key',
         parameters: updatedInstallationParameters,
       });
     } else {

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -138,19 +138,26 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             Welcome to your imgix Contentful app. This is your config page.
           </Paragraph>
           <div>
-            <TextField
-              name="API Key"
-              id="APIKey"
-              labelText="API Key"
-              value={this.state.parameters?.imgixAPIKey || ''}
-              textInputProps={{
-                type: 'password',
-              }}
-              onChange={this.handleChange}
-            />
-            {this.state.parameters.successfullyVerified && (
-                <Icon icon="CheckCircle" size="tiny" color="positive" />
-            )}
+            <div className="flex-container">
+              <div className="flex-child">
+                <TextField
+                  name="API Key"
+                  id="APIKey"
+                  labelText="API Key"
+                  value={this.state.parameters?.imgixAPIKey || ''}
+                  validationMessage={this.state.validationMessage}
+                  textInputProps={{
+                    type: 'password',
+                  }}
+                  onChange={this.handleChange}
+                />
+              </div>
+              {this.state.parameters.successfullyVerified && (
+                <div className="icon">
+                  <Icon icon="CheckCircle" size="tiny" color="positive" />
+                </div>
+              )}
+            </div>
             <p className="ix-helper-text">
               Access your API key at{' '}
               <a

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -6,10 +6,12 @@ import {
   Workbench,
   Paragraph,
   TextField,
+  Notification,
   Button,
 } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
 import './ConfigScreen.css';
+import ImgixAPI from 'imgix-management-js';
 
 export interface AppInstallationParameters {
   imgixAPIKey?: string;
@@ -74,6 +76,23 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   };
 
   verifyAPIKey = async () => {
+    const imgix = new ImgixAPI({
+      apiKey: this.state.parameters.imgixAPIKey || '',
+    });
+
+    try {
+      await imgix.request('sources');
+      Notification.success('Your API Key was successfully confirmed.', {
+        duration: 3000,
+      });
+    } catch (error) {
+      Notification.error(
+        "We couldn't verify this API Key. Confirm your details and try again.",
+        {
+          duration: 3000,
+          },
+      );
+    }
   };
 
   onClick = async () => {

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -79,6 +79,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     this.setState({
       parameters: {
         imgixAPIKey: e.target.value,
+        successfullyVerified: this.state.parameters.successfullyVerified,
       },
     });
   };


### PR DESCRIPTION
This PR is mainly concerned with the following changes:

1) Modifying the `Save` button to now `Verify` a user's API key. More specifically this entails:
	1) Executing a request against the API using the current TextField input value
	2) Displaying either a success/error notification as a result
	3) Displaying a check icon if the latest API key is a valid one
2) Creating an error state when verification is attempted with an empty key
3) Displaying a "loading" button while the verification process is in progress, indicating to users that the action is not yet complete

Successful verification:

https://user-images.githubusercontent.com/15919091/124665483-9fda2600-de61-11eb-88c5-a131a037570b.mov

Unsuccessful verification:

https://user-images.githubusercontent.com/15919091/124665574-ba140400-de61-11eb-96ee-a257b7ecf3f4.mov

Attempt with empty API key value:

https://user-images.githubusercontent.com/15919091/124665602-c4360280-de61-11eb-9b77-6c895eea70e4.mov

