### PR TITLE
feat: add hover styling and select image buttons to image gallery

### DIFF
--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -39,3 +39,7 @@
   font-size: 21px;
   font-weight: 700;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -1,7 +1,7 @@
 .ix-container {
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 50px 100px 460px 50px;
+  grid-template-rows: 50px 100px 470px 50px;
   grid-column-gap: 20px;
 }
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -121,7 +121,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     if (!this.state.renderPlaceholder) {
       return this.state.fullUrls.map((url: string) => (
         <div className="ix-column">
-          <GalleryImage url={url} onClose={() => this.props.sdk.close(url)} />
+          <GalleryImage url={url} />
         </div>
       ));
     } else {

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -28,6 +28,16 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     };
   }
 
+  async componentDidMount() {
+    this.renderImagesOrPlaceholder();
+  }
+
+  async componentDidUpdate(prevProps: GalleryProps) {
+    if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
+      this.renderImagesOrPlaceholder();
+    }
+  }
+
   getImages = async () => {
     return await this.props.imgix.request(
       `assets/${this.props.selectedSource?.id}?page[number]=0&page[size]=18`,
@@ -104,15 +114,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     }
   }
 
-  async componentDidMount() {
-    this.renderImagesOrPlaceholder();
-  }
 
-  async componentDidUpdate(prevProps: GalleryProps) {
-    if (this.props.selectedSource.id !== prevProps.selectedSource.id) {
-      this.renderImagesOrPlaceholder();
-    }
-  }
 
   // stores the placeholder image for the gallery or the acutal images
   images = () => {

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -132,7 +132,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     if (!this.state.renderPlaceholder) {
       return this.state.fullUrls.map((url: string) => (
         <div className="ix-column" onClick={(e) => this.handleImageClick(url)}>
-          <GalleryImage url={url} />
+          <GalleryImage url={url} focus={url === this.state.selectedSource} />
         </div>
       ));
     } else {

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,8 +1,10 @@
-import ImgixAPI, { APIError } from 'imgix-management-js';
 import { Component } from 'react';
-import Imgix from 'react-imgix';
-import { SourceProps } from './Dialog';
+import ImgixAPI, { APIError } from 'imgix-management-js';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
+
+import { SourceProps } from './Dialog';
+import { GalleryImage } from './GalleryImage/GalleryImage';
+
 import './Gallery.css';
 
 interface GalleryProps {
@@ -119,22 +121,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     if (!this.state.renderPlaceholder) {
       return this.state.fullUrls.map((url: string) => (
         <div className="ix-column">
-          <Imgix
-            src={url}
-            // width={100}
-            // height={100}
-            width={70}
-            height={70}
-            imgixParams={{
-              auto: 'format',
-              fit: 'crop',
-              crop: 'entropy',
-            }}
-            sizes="(min-width: 480px) calc(12.5vw - 20px)"
-            htmlAttributes={{
-              onClick: () => this.props.sdk.close(url),
-            }}
-          />
+          <GalleryImage url={url} onClose={() => this.props.sdk.close(url)} />
         </div>
       ));
     } else {

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -4,6 +4,7 @@ import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 
 import { SourceProps } from './Dialog';
 import { GalleryImage } from './GalleryImage/GalleryImage';
+import { GalleryImageSelectButton } from './/GalleryImageSelectButton/GalleryImageSelectButton';
 
 import './Gallery.css';
 
@@ -16,6 +17,7 @@ interface GalleryProps {
 interface GalleryState {
   fullUrls: Array<string>;
   renderPlaceholder: boolean;
+  selectedSource: string;
 }
 
 export default class Gallery extends Component<GalleryProps, GalleryState> {
@@ -25,6 +27,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     this.state = {
       fullUrls: [],
       renderPlaceholder: true,
+      selectedSource: '',
     };
   }
 
@@ -114,7 +117,13 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
     }
   }
 
+  handleImageClick = (url: string) => {
+    this.setState({ selectedSource: url });
+  };
 
+  handleSubmit = (selectedSource: string) => {
+    this.props.sdk.close(selectedSource);
+  };
 
   // stores the placeholder image for the gallery or the acutal images
   images = () => {
@@ -122,7 +131,7 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
 
     if (!this.state.renderPlaceholder) {
       return this.state.fullUrls.map((url: string) => (
-        <div className="ix-column">
+        <div className="ix-column" onClick={(e) => this.handleImageClick(url)}>
           <GalleryImage url={url} />
         </div>
       ));
@@ -155,6 +164,16 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
   };
 
   render() {
-    return <div className="ix-gallery">{this.images()}</div>;
+    const selectedSource = this.state.selectedSource;
+    return (
+      <>
+        <div className="ix-gallery">{this.images()}</div>
+        <GalleryImageSelectButton
+          disabled={this.state.selectedSource === ''} // if no source, disable
+          hidden={this.state.fullUrls.length === 0} // if no images, hide
+          handleClick={(e: any) => this.handleSubmit(selectedSource)}
+        />
+      </>
+    );
   }
 }

--- a/src/components/GalleryImage/GalleryImage.css
+++ b/src/components/GalleryImage/GalleryImage.css
@@ -1,0 +1,26 @@
+.ix-gallery-image {
+  position: relative;
+  z-index: 2;
+}
+.ix-gallery-image-gradient {
+  z-index: 5;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 140px;
+  content: '';
+}
+/* css gradient on hover */
+.ix-gallery-image-gradient:hover {
+  background: rgba(255, 255, 255, 0.424);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 142px;
+  content: '';
+  cursor: pointer;
+}

--- a/src/components/GalleryImage/GalleryImage.css
+++ b/src/components/GalleryImage/GalleryImage.css
@@ -1,6 +1,7 @@
 .ix-gallery-image {
   position: relative;
   z-index: 2;
+  /* height: 136px; */
 }
 .ix-gallery-image-gradient {
   z-index: 5;
@@ -12,6 +13,7 @@
   bottom: 0;
   height: 140px;
   content: '';
+  box-sizing: border-box;
 }
 /* css gradient on hover */
 .ix-gallery-image-gradient:hover {
@@ -20,7 +22,11 @@
   left: 0;
   right: 0;
   bottom: 0;
-  height: 142px;
   content: '';
   cursor: pointer;
+}
+
+/* add blue outline to image on focus */
+.ix-focus > .ix-gallery-image-gradient {
+  border: 4px solid #2e75d4;
 }

--- a/src/components/GalleryImage/GalleryImage.tsx
+++ b/src/components/GalleryImage/GalleryImage.tsx
@@ -5,11 +5,13 @@ import './GalleryImage.css';
 
 interface GalleryImageProps {
   url: string;
+  focus: boolean;
 }
 
-export function GalleryImage({ url }: GalleryImageProps) {
+export function GalleryImage({ url, focus }: GalleryImageProps) {
+  const _focus = focus ? ' ix-focus' : '';
   return (
-    <div className="ix-gallery-image">
+    <div className={'ix-gallery-image' + _focus}>
       <div className="ix-gallery-image-gradient"></div>
       <Imgix
         src={url}

--- a/src/components/GalleryImage/GalleryImage.tsx
+++ b/src/components/GalleryImage/GalleryImage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Imgix from 'react-imgix';
+
+import './GalleryImage.css';
+
+interface GalleryImageProps {
+  url: string;
+  onClose: Function;
+}
+
+export function GalleryImage({ url, onClose }: GalleryImageProps) {
+  return (
+    <div className="ix-gallery-image">
+      <div className="ix-gallery-image-gradient"></div>
+      <Imgix
+        src={url}
+        width={70}
+        height={70}
+        imgixParams={{
+          auto: 'format',
+          fit: 'crop',
+          crop: 'entropy',
+        }}
+        sizes="(min-width: 480px) calc(12.5vw - 20px)"
+        htmlAttributes={{
+          onClick: () => onClose(url),
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/GalleryImage/GalleryImage.tsx
+++ b/src/components/GalleryImage/GalleryImage.tsx
@@ -5,10 +5,9 @@ import './GalleryImage.css';
 
 interface GalleryImageProps {
   url: string;
-  onClose: Function;
 }
 
-export function GalleryImage({ url, onClose }: GalleryImageProps) {
+export function GalleryImage({ url }: GalleryImageProps) {
   return (
     <div className="ix-gallery-image">
       <div className="ix-gallery-image-gradient"></div>
@@ -22,9 +21,6 @@ export function GalleryImage({ url, onClose }: GalleryImageProps) {
           crop: 'entropy',
         }}
         sizes="(min-width: 480px) calc(12.5vw - 20px)"
-        htmlAttributes={{
-          onClick: () => onClose(url),
-        }}
       />
     </div>
   );

--- a/src/components/GalleryImageSelectButton/GalleryImageSelectButton.css
+++ b/src/components/GalleryImageSelectButton/GalleryImageSelectButton.css
@@ -1,0 +1,6 @@
+.ix-gallery-image-select-button {
+  padding-top: 32px;
+  position: absolute;
+  top: 85%;
+  left: 85%;
+}

--- a/src/components/GalleryImageSelectButton/GalleryImageSelectButton.css
+++ b/src/components/GalleryImageSelectButton/GalleryImageSelectButton.css
@@ -1,6 +1,9 @@
-.ix-gallery-image-select-button {
-  padding-top: 32px;
-  position: absolute;
-  top: 85%;
-  left: 85%;
+.ix-gallery-select {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(1fr, 1fr));
+}
+.ix-gallery-select-button {
+  grid-column: 2;
+  justify-self: right;
+  padding: 32px;
 }

--- a/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
+++ b/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+import { Button } from '@contentful/forma-36-react-components';
+
+import './GalleryImageSelectButton.css';
+
+interface GalleryImageSelectButtonProps {
+  handleClick: Function; // Called when the button is clicked
+  disabled: boolean; // Whether the button is disabled
+  hidden: boolean; // Whether the button is hidden
+}
+
+export function GalleryImageSelectButton({
+  handleClick,
+  disabled,
+  hidden,
+}: GalleryImageSelectButtonProps) {
+  const [isSelected, setSelected] = useState(false);
+
+  const onClick = (e: any) => {
+    setSelected(!isSelected);
+    return handleClick(e);
+  };
+
+  return (
+    <div
+      className={
+        hidden
+          ? 'ix-gallery-image-select-button hidden'
+          : 'ix-gallery-image-select-button'
+      }
+    >
+      <Button
+        size="small"
+        buttonType="muted"
+        disabled={disabled}
+        onClick={onClick}
+      >
+        Select image
+      </Button>
+    </div>
+  );
+}

--- a/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
+++ b/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
@@ -32,9 +32,9 @@ export function GalleryImageSelectButton({
     >
       <Button
         size="small"
-        buttonType="muted"
         disabled={disabled}
         onClick={onClick}
+        buttonType={disabled ? 'muted' : 'primary'}
       >
         Select image
       </Button>

--- a/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
+++ b/src/components/GalleryImageSelectButton/GalleryImageSelectButton.tsx
@@ -23,21 +23,17 @@ export function GalleryImageSelectButton({
   };
 
   return (
-    <div
-      className={
-        hidden
-          ? 'ix-gallery-image-select-button hidden'
-          : 'ix-gallery-image-select-button'
-      }
-    >
-      <Button
-        size="small"
-        disabled={disabled}
-        onClick={onClick}
-        buttonType={disabled ? 'muted' : 'primary'}
-      >
-        Select image
-      </Button>
+    <div className={hidden ? 'ix-gallery-select hidden' : 'ix-gallery-select'}>
+      <div className="ix-gallery-select-button">
+        <Button
+          size="small"
+          disabled={disabled}
+          onClick={onClick}
+          buttonType={disabled ? 'muted' : 'primary'}
+        >
+          Select image
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This PR adds styling to the hovered images in the image gallery.

It also adds a `select image` button that sets the source url to the selected image and closes the model on click.

## 📹 

https://user-images.githubusercontent.com/16711614/125366118-775f9980-e343-11eb-8811-1cbc5ab36087.mov


### Changes
- `.hidden` utility style `Dialogue.css`
- on hover styling for images
- on focus styling for images
- selected image button that saves selection and closes modal
- refactored Gallery to organize imports
- refactored Gallery to extract image component for images in gallery

### Discussion
The organization I went here was to place each new component in a folder. With our component count growing, it felt easier to organize styles and component files into folders.

The moving of the lifecycle methods to the top of the component is standard React practice, but it can be undone if it's not preferred.