### PR TITLE
feat: create ImagePlaceholder component

### DIFF
--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -18,13 +18,6 @@
   margin-bottom: 10px;
 }
 
-.ix-placeholder-text {
-  text-align: center;
-  margin-top: 40px;
-  font-size: 21px;
-  font-weight: 700;
-}
-
 @media only screen and (min-width: 481px) {
   .ix-container {
     padding: 40px;

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -151,11 +151,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           imgix={this.state.imgix}
           sdk={this.props.sdk}
         />
-        {!this.state.selectedSource.id && (
-          <Paragraph className="ix-placeholder-text">
-            Select a Source to view your image gallery
-          </Paragraph>
-        )}
       </div>
     );
   }

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -4,6 +4,7 @@ import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 
 import { SourceProps } from '../Dialog';
 import { ImageGrid } from './ImageGrid';
+import { ImagePlaceholder } from './ImagePlaceholder';
 
 import './ImageGallery.css';
 
@@ -115,6 +116,9 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
   }
 
   render() {
+    if (this.state.fullUrls.length === 0) {
+      return <ImagePlaceholder />;
+    }
     return (
       <div className="ix-gallery">
         <ImageGrid

--- a/src/components/Gallery/ImagePlaceholder.css
+++ b/src/components/Gallery/ImagePlaceholder.css
@@ -1,5 +1,5 @@
 .ix-grid-item-placeholder {
-  margin: 32px;
+  margin-top: 32px;
   height: 250px;
   border: 2px solid #eeeded;
   border-radius: 4px;

--- a/src/components/Gallery/ImagePlaceholder.css
+++ b/src/components/Gallery/ImagePlaceholder.css
@@ -1,0 +1,16 @@
+.ix-grid-item-placeholder {
+  margin: 32px;
+  height: 250px;
+  border: 2px solid #eeeded;
+  border-radius: 4px;
+  display: flex;
+  background: #fafafa;
+  justify-content: center;
+  align-items: center;
+}
+
+.ix-placeholder-text {
+  text-align: center;
+  font-size: 21px;
+  font-weight: 700;
+}

--- a/src/components/Gallery/ImagePlaceholder.tsx
+++ b/src/components/Gallery/ImagePlaceholder.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from 'react';
+import { Paragraph } from '@contentful/forma-36-react-components';
+
+import './ImagePlaceholder.css';
+
+interface Props {}
+
+export function ImagePlaceholder({}: Props): ReactElement {
+  return (
+    <div className="ix-grid-item-placeholder">
+      <Paragraph className="ix-placeholder-text">
+        Select a Source to view your image gallery
+      </Paragraph>
+    </div>
+  );
+}


### PR DESCRIPTION
> This is a stacked PR, please review the linked `diff`

**PR Stack**
| PR 	| Title 	| Merges Into 	|   diff	|
|----	|-------	|-------------	|---	|
|    1	|    refactor: #40  	|        design-updates    	|  [diff](https://github.com/imgix/contentful/pull/40)	|
|    2	|    [ImagePlaceholder](#41)     	|           #40   	|   [diff](https://github.com/imgix/contentful/pull/41/files/2dd79eb..f530cac)	|

This PR removes the placeholder element fro the Gallery component and uses the new ImagePlaceholder component instead. It also removes the placeholder text from the Dialogue component and its corresponding styles, since those are now housed in the ImagePlaceholder.

## Example image
<img width="793" alt="placeholder-box" src="https://user-images.githubusercontent.com/16711614/125666759-bfc6fde4-9db9-40a0-bfc2-185bc3cc45f9.png">
