### PR TITLE
feat(dialog): add buttons to page between Source's images

### DIFF
--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -43,7 +43,8 @@
 }
 
 .ix-chevron-right {
-  margin-top: 5px;
+  padding-top: 5px;
+  padding-left: 3px;
 }
 
 .Button__Button___1ZfFj

--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -30,3 +30,9 @@
     padding-right: 64px;
   }
 }
+
+.ix-pagination {
+  margin-left: 32px;
+  margin-top: 32px;
+  grid-row: 4;
+}

--- a/src/components/Dialog.css
+++ b/src/components/Dialog.css
@@ -36,3 +36,18 @@
   margin-top: 32px;
   grid-row: 4;
 }
+
+.ix-next-page-button {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+}
+
+.ix-chevron-right {
+  margin-top: 5px;
+}
+
+.Button__Button___1ZfFj
+  Button__Button--muted___2Wair
+  Button__Button--small___3yyrk {
+  width: 120px;
+}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -5,6 +5,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownListItem,
+  Icon,
 } from '@contentful/forma-36-react-components';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { AppInstallationParameters } from './ConfigScreen';
@@ -151,6 +152,27 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           imgix={this.state.imgix}
           sdk={this.props.sdk}
         />
+        {this.state.selectedSource.id && (
+            <Button buttonType="muted" icon="ChevronLeft" size="small">
+              Prev Page
+            </Button>
+            <Dropdown
+              toggleElement={
+                <Button size="small" buttonType="muted" indicateDropdown>
+                  {'Page 1 of 5'} {/* TODO: replace placeholder */}
+                </Button>
+              }
+            >
+              {/* placeholder */}
+            </Dropdown>
+            <Button buttonType="muted" size="small">
+                Next Page
+                <Icon
+                  color="secondary"
+                  icon="ChevronRight"
+                />
+            </Button>
+        )}
       </div>
     );
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -97,6 +97,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
+  handleTotalImageCount = (totalImageCount: number) => {
+    this.setState({ totalImageCount });
+  }
+
   setOpen = (isOpen: boolean, selectedSource?: SourceProps) => {
     if (selectedSource) {
       this.setState({ isOpen, selectedSource });
@@ -153,6 +157,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           selectedSource={this.state.selectedSource}
           imgix={this.state.imgix}
           sdk={this.props.sdk}
+          getTotalImageCount={this.handleTotalImageCount}
         />
         {this.state.selectedSource.id && (
           <div className="ix-pagination">

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -22,6 +22,7 @@ interface DialogState {
   isOpen: boolean;
   allSources: Array<SourceProps>;
   selectedSource: Partial<SourceProps>;
+  totalImageCount: number;
 }
 
 export type SourceProps = {
@@ -46,6 +47,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       isOpen: false,
       allSources: [],
       selectedSource: {},
+      totalImageCount: 0,
     };
   }
 
@@ -160,7 +162,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             <Dropdown
               toggleElement={
                 <Button size="small" buttonType="muted" indicateDropdown>
-                  {'Page 1 of 5'} {/* TODO: replace placeholder */}
+                  {'Page 1 of '} {Math.ceil(this.state.totalImageCount / 18)}
                 </Button>
               }
             >

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -153,6 +153,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           sdk={this.props.sdk}
         />
         {this.state.selectedSource.id && (
+          <div className="ix-pagination">
             <Button buttonType="muted" icon="ChevronLeft" size="small">
               Prev Page
             </Button>
@@ -172,6 +173,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                   icon="ChevronRight"
                 />
             </Button>
+          </div>
         )}
       </div>
     );

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -99,7 +99,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   handleTotalImageCount = (totalImageCount: number) => {
     this.setState({ totalImageCount });
-  }
+  };
 
   setOpen = (isOpen: boolean, selectedSource?: SourceProps) => {
     if (selectedSource) {

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -167,11 +167,14 @@ export default class Dialog extends Component<DialogProps, DialogState> {
               {/* placeholder */}
             </Dropdown>
             <Button buttonType="muted" size="small">
+              <div className="ix-next-page-button">
                 Next Page
                 <Icon
+                  className="ix-chevron-right"
                   color="secondary"
                   icon="ChevronRight"
                 />
+              </div>
             </Button>
           </div>
         )}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -12,6 +12,7 @@ interface GalleryProps {
   selectedSource: Partial<SourceProps>;
   imgix: ImgixAPI;
   sdk: DialogExtensionSDK;
+  getTotalImageCount: (totalImageCount: number) => void;
 }
 
 interface GalleryState {
@@ -30,9 +31,12 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
   }
 
   getImages = async () => {
-    return await this.props.imgix.request(
+    const assets = await this.props.imgix.request(
       `assets/${this.props.selectedSource?.id}?page[number]=0&page[size]=18`,
     );
+    // TODO: add more explicit types for image
+    this.props.getTotalImageCount(parseInt((assets.meta.cursor as any).totalRecords));
+    return assets;
   };
 
   getImagePaths = async () => {

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -35,7 +35,9 @@ export default class Gallery extends Component<GalleryProps, GalleryState> {
       `assets/${this.props.selectedSource?.id}?page[number]=0&page[size]=18`,
     );
     // TODO: add more explicit types for image
-    this.props.getTotalImageCount(parseInt((assets.meta.cursor as any).totalRecords));
+    this.props.getTotalImageCount(
+      parseInt((assets.meta.cursor as any).totalRecords),
+    );
     return assets;
   };
 


### PR DESCRIPTION
This PR is mainly concerned with adding the basic UI for pagination and the handler to pass total asset count from the Gallery to the Dialog. All logic for actual pagination will be handled in a different PR.

Note: There is a weird occurrence where the pagination dropdown appears as `Page 1 out of 0` while loading in assets. This will also be addressed in a subsequent PR.

https://user-images.githubusercontent.com/15919091/125686855-c01ead9e-133b-4d98-b59f-44571f16e5b1.mov

