### PR TITLE
feat: add handler to change the page when an item from the dropdown is selected

### DIFF
--- a/src/components/Dialog/Dialog.spec.tsx
+++ b/src/components/Dialog/Dialog.spec.tsx
@@ -13,6 +13,6 @@ describe('Dialog component', () => {
     };
 
     const { getByText } = render(<Dialog sdk={mockSdk} />);
-    expect(getByText('Hello Dialog Component')).toBeInTheDocument();
+    expect(getByText('imgix Source:')).toBeInTheDocument();
   });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -101,11 +101,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
-  handleTotalImageCount = (totalImageCount: number) => {
+  handleTotalImageCount = (totalImageCount: number) =>
     this.setState({
       page: { current: 1, totalPageCount: Math.ceil(totalImageCount / 18) },
     });
-  };
 
   setSelectedSource = (source: SourceProps) => {
     this.setState({ selectedSource: source });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -106,6 +106,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       page: { current: 1, totalPageCount: Math.ceil(totalImageCount / 18) },
     });
 
+  handlePageChange = (newPageIndex: number) =>
+    this.setState({ page: { ...this.state.page, current: newPageIndex } });
+
   setSelectedSource = (source: SourceProps) => {
     this.setState({ selectedSource: source });
   };
@@ -133,6 +136,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           sdk={sdk}
           getTotalImageCount={this.handleTotalImageCount}
           pageInfo={page}
+          changePage={this.handlePageChange}
         />
       </div>
     );

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -13,6 +13,7 @@ interface GalleryProps {
   sdk: DialogExtensionSDK;
   getTotalImageCount: (totalImageCount: number) => void;
   pageInfo: PageProps;
+  changePage: (newPageIndex: number) => void;
 }
 
 interface GalleryState {
@@ -136,6 +137,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
         <ImagePagination
           sourceId={this.props.selectedSource.id}
           pageInfo={this.props.pageInfo}
+          changePage={this.props.changePage}
         />
       </div>
     );

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -14,15 +14,18 @@ import './ImagePagination.css';
 interface Props {
   sourceId: string | undefined;
   pageInfo: PageProps;
+  changePage: (newIndex: number) => void;
 }
 
 export function ImagePagination({
   sourceId,
   pageInfo,
+  changePage,
 }: Props): ReactElement {
   const [isOpen, setOpen] = React.useState(false);
   const handleDropdownClick = (newPageIndex: number) => {
     setOpen(false);
+    changePage(newPageIndex);
   };
 
   if (sourceId == undefined) {

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -1,5 +1,11 @@
 import React, { ReactElement } from 'react';
-import { Button, Dropdown, Icon } from '@contentful/forma-36-react-components';
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+  Icon,
+} from '@contentful/forma-36-react-components';
 
 import { PageProps } from '../Dialog';
 
@@ -10,7 +16,15 @@ interface Props {
   pageInfo: PageProps;
 }
 
-export function ImagePagination({ sourceId, pageInfo }: Props): ReactElement {
+export function ImagePagination({
+  sourceId,
+  pageInfo,
+}: Props): ReactElement {
+  const [isOpen, setOpen] = React.useState(false);
+  const handleDropdownClick = (newPageIndex: number) => {
+    setOpen(false);
+  };
+
   if (sourceId == undefined) {
     // return react fragment if no sourceId is provided
     return <></>;
@@ -21,13 +35,34 @@ export function ImagePagination({ sourceId, pageInfo }: Props): ReactElement {
         Prev Page
       </Button>
       <Dropdown
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
         toggleElement={
-          <Button size="small" buttonType="muted" indicateDropdown>
+          <Button
+            size="small"
+            buttonType="muted"
+            indicateDropdown
+            onClick={() => setOpen(!isOpen)}
+          >
             {'Page ' + pageInfo.current + ' of ' + pageInfo.totalPageCount}
           </Button>
         }
       >
-        {/* placeholder */}
+        <DropdownList maxHeight={111}>
+          {/* a maxHeight of 111 is the minimum height to fit 3 entries without
+          needing to scroll */}
+          {[...Array(pageInfo.totalPageCount)].map((_, _pageIndex) => {
+            const pageIndex = _pageIndex + 1;
+            return (
+              <DropdownListItem
+                key={`page-${pageIndex}`}
+                onClick={() => handleDropdownClick(pageIndex)}
+              >
+                {'Page ' + pageIndex}
+              </DropdownListItem>
+            );
+          })}
+        </DropdownList>
       </Dropdown>
       <Button buttonType="muted" size="small">
         <div className="ix-next-page-button">


### PR DESCRIPTION
This PR is only concerned with populating the pagination dropdown and setting the handler to (superficially) change the page. In the subsequent PR, the new page index will be passed through the management API to retrieve the new assets. 

Also note that this PR does not style the dropdown list items, which are currently more narrow than the parent element.

https://user-images.githubusercontent.com/15919091/125851152-f4f022a9-4ed0-42f0-8d22-38468b72f09f.mov

