### PR TITLE
feat(gallery): add `onClick` handlers for paginating forward and back

### DIFF
--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -42,14 +42,18 @@ export function ImagePagination({
     }
   };
 
-
   if (sourceId == undefined) {
     // return react fragment if no sourceId is provided
     return <></>;
   }
   return (
     <div className="ix-pagination">
-      <Button buttonType="muted" icon="ChevronLeft" size="small">
+      <Button
+        buttonType="muted"
+        icon="ChevronLeft"
+        size="small"
+        onClick={() => paginateBackward()}
+      >
         Prev Page
       </Button>
       <Dropdown
@@ -82,7 +86,7 @@ export function ImagePagination({
           })}
         </DropdownList>
       </Dropdown>
-      <Button buttonType="muted" size="small">
+      <Button buttonType="muted" size="small" onClick={() => paginateForward()}>
         <div className="ix-next-page-button">
           Next Page
           <Icon

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -30,14 +30,12 @@ export function ImagePagination({
   const paginateForward = () => {
     const nextPage = pageInfo.currentIndex + 1;
     if (nextPage < pageInfo.totalPageCount) {
-      console.log('going to next page');
       changePage(nextPage);
     }
   };
   const paginateBackward = () => {
     const prevPage = pageInfo.currentIndex - 1;
     if (prevPage >= 0) {
-      console.log('going to prev page');
       changePage(prevPage);
     }
   };

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -27,6 +27,21 @@ export function ImagePagination({
     setOpen(false);
     changePage(newPageIndex);
   };
+  const paginateForward = () => {
+    const nextPage = pageInfo.currentIndex + 1;
+    if (nextPage < pageInfo.totalPageCount) {
+      console.log('going to next page');
+      changePage(nextPage);
+    }
+  };
+  const paginateBackward = () => {
+    const prevPage = pageInfo.currentIndex - 1;
+    if (prevPage >= 0) {
+      console.log('going to prev page');
+      changePage(prevPage);
+    }
+  };
+
 
   if (sourceId == undefined) {
     // return react fragment if no sourceId is provided


### PR DESCRIPTION
This PR adds onClick handlers for paginating forward and back between all available pages for a Source.

It's worth noting that rapidly pressing either button will cause a ratelimit by the API and for the current index and actual displayed page to become out of sync. This edge case will be handled in a subsequent PR which will add onClick debouncing to various parts of the app.

https://user-images.githubusercontent.com/15919091/125866393-0b5da160-0218-4830-8f2e-60903d8c6c5f.mov

