### PR TITLE
feat: warning notification on no source assetes

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -14,3 +14,7 @@
     padding-right: 64px;
   }
 }
+
+[data-test-id='cf-ui-notification'] {
+  margin-bottom: 40vh;
+}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import { Notification } from '@contentful/forma-36-react-components';
 
 import { DialogHeader } from './';
 import { AppInstallationParameters } from '../ConfigScreen/';
@@ -101,13 +102,20 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
-  handleTotalImageCount = (totalImageCount: number) =>
+  handleTotalImageCount = (totalImageCount: number) => {
+    if (totalImageCount === 0) {
+      Notification.warning('No images found in the current space.', {
+        duration: 3000,
+      });
+    }
+
     this.setState({
       page: {
         ...this.state.page,
         totalPageCount: Math.ceil(totalImageCount / 18),
       },
     });
+  };
 
   handlePageChange = (newPageIndex: number) =>
     this.setState({ page: { ...this.state.page, currentIndex: newPageIndex } });

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -40,8 +40,9 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     );
     // TODO: add more explicit types for image
     this.props.getTotalImageCount(
-      parseInt((assets.meta.cursor as any).totalRecords),
+      parseInt((assets.meta.cursor as any).totalRecords || 0),
     );
+
     return assets;
   };
 


### PR DESCRIPTION
This PR uses the f36 `Notification` component to display an error dialog when there are no images in a given source.

## Video

https://user-images.githubusercontent.com/16711614/125969938-aad2e74f-48e6-4f5d-b22a-65124a9da2c2.mov

## Future work

- Add flavor text that matches design comps
- Display a warning when there are no sources on the account