### PR TITLE
feat: show warning and render placeholder when imgix source has no assets

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -14,3 +14,7 @@
     padding-right: 64px;
   }
 }
+
+[data-test-id='cf-ui-notification'] {
+  margin-bottom: 40vh;
+}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -39,7 +39,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     );
     // TODO: add more explicit types for image
     this.props.getTotalImageCount(
-      parseInt((assets.meta.cursor as any).totalRecords),
+      parseInt((assets.meta.cursor as any).totalRecords || 0),
     );
     return assets;
   };

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -108,10 +108,19 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
       console.log(fullUrls);
 
       if (fullUrls.length) {
+        // close no-images warning and update state with image urls
+        Notification.close('no-origin-images');
         this.setState({ fullUrls });
       } else {
-        Notification.warning('No images found in the current space.', {
-          duration: 3000,
+        // show no-images warning and set state with empty images array
+        Notification.warning('', {
+          title: 'This Source has no Origin images',
+          id: 'no-origin-images',
+          cta: {
+            label: 'Go to the imgix dashboard to add origin images',
+            textLinkProps: { href: 'https://dashboard.imgix.com' },
+          },
+          duration: 10000,
         });
         this.setState({ fullUrls: [] });
       }

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -105,7 +105,6 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
       const images = await this.getImagePaths();
       const fullUrls = this.constructUrl(images);
       // if at least one path, remove placeholders
-      console.log(fullUrls);
 
       if (fullUrls.length) {
         // close no-images warning and update state with image urls


### PR DESCRIPTION
This PR uses the f36 Notification component to display an error dialog when there are no images in a given source. The warning is dismissed when the source is changed and successfully loads images.

This PR also ensures `0` is returned as the image count instead of `NaN` when a source returns no images.

This PR also removes the unused `renderPlaceholder` boolean from the component state.

## Video

https://user-images.githubusercontent.com/16711614/125988357-3627c3bf-747e-4e82-980e-6964c18707d0.mov

