### PR TITLE
feat: show warning when imgix account has no enabled sources

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import { Notification } from '@contentful/forma-36-react-components';
 
 import { DialogHeader } from './';
 import { AppInstallationParameters } from '../ConfigScreen/';
@@ -59,6 +60,18 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return this.state.imgix.request('sources');
   };
 
+  showNoEnabledSourceNotification = () => {
+    Notification.warning('', {
+      title: 'This imgix account has no enabled Sources',
+      id: 'no-origin-sources',
+      cta: {
+        label: 'Go to the imgix dashboard to add sources',
+        textLinkProps: { href: 'https://dashboard.imgix.com' },
+      },
+      duration: 10000,
+    });
+  };
+
   getSourceIDAndPaths = async (): Promise<Array<SourceProps>> => {
     let sources,
       enabledSources: Array<SourceProps> = [];
@@ -97,6 +110,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       },
       [] as SourceProps[],
     );
+
+    if (!enabledSources.length) {
+      this.showNoEnabledSourceNotification();
+    }
 
     return enabledSources;
   };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -56,7 +56,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   }
 
   getSources = async () => {
-    return await this.state.imgix.request('sources');
+    return this.state.imgix.request('sources');
   };
 
   getSourceIDAndPaths = async (): Promise<Array<SourceProps>> => {

--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -26,6 +26,12 @@ export function SourceSelectDropdown({
     setSource(source);
   };
 
+  const dropDownText = allSources.length
+    ? 'Select an imgix Source'
+    : 'No sources';
+
+  const buttonType = allSources.length ? 'muted' : 'warning';
+
   return (
     <Dropdown
       className="ix-dropdown"
@@ -34,11 +40,11 @@ export function SourceSelectDropdown({
       toggleElement={
         <Button
           size="small"
-          buttonType="muted"
+          buttonType={buttonType}
           indicateDropdown
           onClick={() => setOpen(!isOpen)}
         >
-          {selectedSource.name || 'Select an imgix Source'}
+          {selectedSource.name || dropDownText}
         </Button>
       }
     >


### PR DESCRIPTION
> This is a stacked PR, please review the linked `diff`

**PR Stack**
| PR 	| Title 	| Merges Into 	|   diff	|
|----	|-------	|-------------	|---	|
|    1	|    [no-source-error](https://github.com/imgix/contentful/pull/54)   👈🏼  |          design-updates  	|   [diff](https://github.com/imgix/contentful/pull/54/files)|
|    2	|    [invalid-api-key](https://github.com/imgix/contentful/pull/56)  	|           #54   	|   [diff](https://github.com/imgix/contentful/pull/56/files/4b0a67d..50cafc3)	|

This PR makes it so the `Dialog.tsx` component shows a warning when the imgix account has no enabled sources. The PR also has the `SourceSelect.tsx` component change colors and placeholder text if there are no enabled sources.

## 📹 

https://user-images.githubusercontent.com/16711614/126345808-8c187eff-df7b-4b6d-bb63-3cf41e4b6848.mov


## Future work

The button color and copy changes are not "to spec" since they're not in the comps. They can be removed if they're deemed a little too "loud".