### PR TITLE
feat(field): allow a selected image to be replaced or removed

### DIFF
--- a/src/components/Field/Field.spec.tsx
+++ b/src/components/Field/Field.spec.tsx
@@ -8,6 +8,9 @@ describe('Field component', () => {
       field: {
         getValue: () => {},
       },
+      window: {
+        updateHeight: () => {},
+      },
     };
 
     const { getByText } = render(<Field sdk={mockSdk} />);

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -54,7 +54,11 @@ export default class Field extends Component<FieldProps, FieldState> {
         />
       );
     } else {
-      return <FieldPrompt onClick={this.openDialog} />;
+      return (
+        <FieldPrompt
+          openDialog={this.openDialog}
+        />
+      );
     }
   }
 }

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -30,6 +30,7 @@ export default class Field extends Component<FieldProps, FieldState> {
         minHeight: 1200,
         position: 'top',
         shouldCloseOnOverlayClick: true,
+        allowHeightOverflow: true,
       })
       .then((imagePath) =>
         this.setState({ imagePath }, () =>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -45,11 +45,13 @@ export default class Field extends Component<FieldProps, FieldState> {
   };
 
   render() {
+    const updateHeightHandler = this.props.sdk.window.updateHeight;
     if (this.state.imagePath) {
       return (
         <FieldImagePreview
           imagePath={this.state.imagePath}
           openDialog={this.openDialog}
+          updateHeight={updateHeightHandler}
           clearSelection={this.clearSelection}
         />
       );
@@ -57,6 +59,7 @@ export default class Field extends Component<FieldProps, FieldState> {
       return (
         <FieldPrompt
           openDialog={this.openDialog}
+          updateHeight={updateHeightHandler}
         />
       );
     }

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -9,7 +9,7 @@ interface FieldProps {
 }
 
 interface FieldState {
-  imagePath: string;
+  imagePath: string | undefined;
 }
 
 export default class Field extends Component<FieldProps, FieldState> {
@@ -38,9 +38,21 @@ export default class Field extends Component<FieldProps, FieldState> {
       );
   };
 
+  clearSelection = () => {
+    this.setState({ imagePath: undefined }, () =>
+      this.props.sdk.field.setValue(undefined),
+    );
+  };
+
   render() {
     if (this.state.imagePath) {
-      return <FieldImagePreview imagePath={this.state.imagePath} />;
+      return (
+        <FieldImagePreview
+          imagePath={this.state.imagePath}
+          openDialog={this.openDialog}
+          clearSelection={this.clearSelection}
+        />
+      );
     } else {
       return <FieldPrompt onClick={this.openDialog} />;
     }

--- a/src/components/Field/FieldImagePreview.css
+++ b/src/components/Field/FieldImagePreview.css
@@ -1,3 +1,24 @@
-.ix-field-image {
-  height: 311px;
+.ix-field-image-preview {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(2, 1fr);
+  grid-column-gap: 0px;
+  grid-row-gap: 16px;
+  width: 230px;
+}
+
+.ix-field-image-preview-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 1fr;
+  grid-column-gap: 16px;
+  grid-row-gap: 0px;
+}
+
+.ix-field-image-preview-buttons-replace > span {
+  padding: 0px;
+}
+
+.ix-field-image-preview-buttons-remove > span {
+  padding: 0px;
 }

--- a/src/components/Field/FieldImagePreview.tsx
+++ b/src/components/Field/FieldImagePreview.tsx
@@ -6,6 +6,7 @@ import './FieldImagePreview.css';
 
 interface FieldImagePreviewProps {
   imagePath: string;
+  updateHeight: Function;
   openDialog: Function;
   clearSelection: Function;
 }
@@ -13,8 +14,10 @@ interface FieldImagePreviewProps {
 export function FieldImagePreview({
   imagePath,
   openDialog,
+  updateHeight,
   clearSelection,
 }: FieldImagePreviewProps): ReactElement {
+  updateHeight(311);
   return (
     <div className="ix-field-image-preview">
       <Imgix

--- a/src/components/Field/FieldImagePreview.tsx
+++ b/src/components/Field/FieldImagePreview.tsx
@@ -16,10 +16,10 @@ export function FieldImagePreview({
   clearSelection,
 }: FieldImagePreviewProps): ReactElement {
   return (
-    <div className="ix-field-image">
+    <div className="ix-field-image-preview">
       <Imgix
-        width={191}
-        height={191}
+        width={230}
+        height={230}
         src={imagePath}
         imgixParams={{
           auto: 'format',
@@ -27,7 +27,9 @@ export function FieldImagePreview({
           crop: 'entropy',
         }}
       />
+      <div className="ix-field-image-preview-buttons">
         <Button
+          className="ix-field-image-preview-buttons-replace"
           icon="Plus"
           buttonType="primary"
           onClick={() => openDialog()}
@@ -35,12 +37,14 @@ export function FieldImagePreview({
           Replace
         </Button>
         <Button
+          className="ix-field-image-preview-buttons-remove"
           icon="Delete"
           buttonType="negative"
           onClick={() => clearSelection()}
         >
           Remove
         </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/Field/FieldImagePreview.tsx
+++ b/src/components/Field/FieldImagePreview.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-
+import { Button } from '@contentful/forma-36-react-components';
 import Imgix from 'react-imgix';
 
 import './FieldImagePreview.css';
@@ -23,6 +23,18 @@ export function FieldImagePreview({
           crop: 'entropy',
         }}
       />
+        <Button
+          icon="Plus"
+          buttonType="primary"
+        >
+          Replace
+        </Button>
+        <Button
+          icon="Delete"
+          buttonType="negative"
+        >
+          Remove
+        </Button>
     </div>
   );
 }

--- a/src/components/Field/FieldImagePreview.tsx
+++ b/src/components/Field/FieldImagePreview.tsx
@@ -6,10 +6,14 @@ import './FieldImagePreview.css';
 
 interface FieldImagePreviewProps {
   imagePath: string;
+  openDialog: Function;
+  clearSelection: Function;
 }
 
 export function FieldImagePreview({
   imagePath,
+  openDialog,
+  clearSelection,
 }: FieldImagePreviewProps): ReactElement {
   return (
     <div className="ix-field-image">
@@ -26,12 +30,14 @@ export function FieldImagePreview({
         <Button
           icon="Plus"
           buttonType="primary"
+          onClick={() => openDialog()}
         >
           Replace
         </Button>
         <Button
           icon="Delete"
           buttonType="negative"
+          onClick={() => clearSelection()}
         >
           Remove
         </Button>

--- a/src/components/Field/FieldPrompt.tsx
+++ b/src/components/Field/FieldPrompt.tsx
@@ -4,16 +4,18 @@ import { Button } from '@contentful/forma-36-react-components';
 import './FieldPrompt.css';
 
 interface FieldPromptProps {
-  onClick: Function;
+  openDialog: Function;
 }
 
-export function FieldPrompt({ onClick }: FieldPromptProps): ReactElement {
+export function FieldPrompt({
+  openDialog,
+}: FieldPromptProps): ReactElement {
   return (
     <div className="ix-field-prompt">
       <Button
         className="ix-add-image-button"
         icon="Plus"
-        onClick={() => onClick()}
+        onClick={() => openDialog()}
       >
         Add An Origin Image
       </Button>

--- a/src/components/Field/FieldPrompt.tsx
+++ b/src/components/Field/FieldPrompt.tsx
@@ -5,11 +5,14 @@ import './FieldPrompt.css';
 
 interface FieldPromptProps {
   openDialog: Function;
+  updateHeight: Function;
 }
 
 export function FieldPrompt({
   openDialog,
+  updateHeight,
 }: FieldPromptProps): ReactElement {
+  updateHeight(150);
   return (
     <div className="ix-field-prompt">
       <Button


### PR DESCRIPTION
This PR adds two new buttons: `Replace` and `Remove` to the Field component when the field already has a value (image) saved. It also adds styling to format each child component appropriately and resizes the containing iframe depending on which one is being displayed.

https://user-images.githubusercontent.com/15919091/126348867-5a9030db-ffa5-4e44-b594-bf0887724754.mov

