### PR TITLE
feat: show warning on invalid API key save

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import { Notification } from '@contentful/forma-36-react-components';
 
 import { DialogHeader } from './';
 import { AppInstallationParameters } from '../ConfigScreen/';
@@ -59,6 +60,18 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return this.state.imgix.request('sources');
   };
 
+  showNoEnabledSourceNotification = () => {
+    Notification.warning('', {
+      title: 'This imgix account has no enabled Sources',
+      id: 'no-origin-sources',
+      cta: {
+        label: 'Go to the imgix dashboard to add sources',
+        textLinkProps: { href: 'https://dashboard.imgix.com' },
+      },
+      duration: 10000,
+    });
+  };
+
   getSourceIDAndPaths = async (): Promise<Array<SourceProps>> => {
     let sources,
       enabledSources: Array<SourceProps> = [];
@@ -97,6 +110,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       },
       [] as SourceProps[],
     );
+
+    if (!enabledSources.length) {
+      this.showNoEnabledSourceNotification();
+    }
 
     return enabledSources;
   };

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -118,13 +118,20 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return enabledSources;
   };
 
-  handleTotalImageCount = (totalImageCount: number) =>
+  handleTotalImageCount = (totalImageCount: number) => {
+    if (totalImageCount === 0) {
+      Notification.warning('No images found in the current space.', {
+        duration: 3000,
+      });
+    }
+
     this.setState({
       page: {
         ...this.state.page,
         totalPageCount: Math.ceil(totalImageCount / 18),
       },
     });
+  };
 
   handlePageChange = (newPageIndex: number) =>
     this.setState({ page: { ...this.state.page, currentIndex: newPageIndex } });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -79,12 +79,20 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     try {
       sources = await this.getSources();
     } catch (error) {
+      const err = { ...error };
+      const errorName = err.name;
+      const errorMessage = err.response.errors[0].detail;
       // APIError will emit more helpful data for debugging
       if (error instanceof APIError) {
         console.error(error.toString());
       } else {
         console.error(error);
       }
+
+      Notification.error(errorMessage, {
+        title: errorName || 'imgix API Error',
+        duration: 10000,
+      });
       return enabledSources;
     }
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -56,7 +56,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   }
 
   getSources = async () => {
-    return await this.state.imgix.request('sources');
+    return this.state.imgix.request('sources');
   };
 
   getSourceIDAndPaths = async (): Promise<Array<SourceProps>> => {

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -41,6 +41,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     this.props.getTotalImageCount(
       parseInt((assets.meta.cursor as any).totalRecords || 0),
     );
+
     return assets;
   };
 

--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -26,6 +26,12 @@ export function SourceSelectDropdown({
     setSource(source);
   };
 
+  const dropDownText = allSources.length
+    ? 'Select an imgix Source'
+    : 'No sources';
+
+  const buttonType = allSources.length ? 'muted' : 'warning';
+
   return (
     <Dropdown
       className="ix-dropdown"
@@ -34,11 +40,11 @@ export function SourceSelectDropdown({
       toggleElement={
         <Button
           size="small"
-          buttonType="muted"
+          buttonType={buttonType}
           indicateDropdown
           onClick={() => setOpen(!isOpen)}
         >
-          {selectedSource.name || 'Select an imgix Source'}
+          {selectedSource.name || dropDownText}
         </Button>
       }
     >


### PR DESCRIPTION
> This is a stacked PR, please review the linked `diff`

**PR Stack**
| PR 	| Title 	| Merges Into 	|   diff	|
|----	|-------	|-------------	|---	|
|    1	|    [no-source-error](https://github.com/imgix/contentful/pull/54)     	|          design-updates  	|   [diff](https://github.com/imgix/contentful/pull/54/files)|
|    2	|    [invalid-api-key](https://github.com/imgix/contentful/pull/56)   👈🏼 	|           #54   	|   [diff](https://github.com/imgix/contentful/pull/56/files/4b0a67d..50cafc3)	|

This PR shows an error warning if an invalid API key is saved on the configuration screen or is present when loading the Dialog.

## Video 🎥 

https://user-images.githubusercontent.com/16711614/126352272-e8cd4661-62f6-47f3-bfa9-a7da93b1dd66.mov

https://user-images.githubusercontent.com/16711614/126352270-6123398f-0db1-4fa3-8d0c-f6923847d9c3.mov

## Future work

As things stand the current error returned is the same one from the request-response. This could be changed to more closely match the comp. copy.
