### PR TITLE
feat: handle API error and warnings in the Dialog component

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -45,12 +45,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   constructor(props: DialogProps) {
     super(props);
 
-    const apiKey =
-      (props.sdk.parameters.installation as AppInstallationParameters)
-        .imgixAPIKey || '';
-    const verified = !!(
-      props.sdk.parameters.installation as AppInstallationParameters
-    ).successfullyVerified;
+    const installationParameters =
+      (props.sdk.parameters.installation as AppInstallationParameters);
+    const apiKey = installationParameters.imgixAPIKey || ''
+    const verified = !!installationParameters.successfullyVerified;
     const imgix = new ImgixAPI({
       apiKey,
     });
@@ -64,7 +62,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         currentIndex: 0,
         totalPageCount: 1,
       },
-      verified: verified,
+      verified,
       errors: [],
     };
   }

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -107,20 +107,8 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
       // if at least one path, remove placeholders
 
       if (fullUrls.length) {
-        // close no-images warning and update state with image urls
-        Notification.close('no-origin-images');
         this.setState({ fullUrls });
       } else {
-        // show no-images warning and set state with empty images array
-        Notification.warning('', {
-          title: 'This Source has no Origin images',
-          id: 'no-origin-images',
-          cta: {
-            label: 'Go to the imgix dashboard to add origin images',
-            textLinkProps: { href: 'https://dashboard.imgix.com' },
-          },
-          duration: 10000,
-        });
         this.setState({ fullUrls: [] });
       }
     }

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -1,7 +1,6 @@
 import { Component } from 'react';
 import ImgixAPI, { APIError } from 'imgix-management-js';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
-import { Notification } from '@contentful/forma-36-react-components';
 
 import { SourceProps, PageProps } from '../Dialog';
 import { ImageSelectButton } from '../ImageSelect/ImageSelect';

--- a/src/components/Note/Note.css
+++ b/src/components/Note/Note.css
@@ -1,0 +1,3 @@
+.ix-note {
+  margin-top: 25px;
+}

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -1,0 +1,36 @@
+import { ReactElement } from 'react';
+import { Note, TextLink } from '@contentful/forma-36-react-components';
+
+export interface INoteProps {
+  type: 'primary' | 'positive' | 'negative' | 'warning';
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export function IxNote({
+  error,
+  type,
+  resetErrorBoundary,
+}: INoteProps): ReactElement {
+  const [message, _link, ...rest] = error.message.split('$');
+  const [link, title] = _link.split('|');
+  const linkTitle = title?.length ? title : link;
+  console.log(message, link, ...rest);
+
+  return (
+    <div className="ix-note" style={{ marginTop: 25 }}>
+      <Note
+        noteType={type}
+        title={error.name}
+        hasCloseButton
+        onClose={resetErrorBoundary}
+      >
+        {message + ' '}{' '}
+        <TextLink target="window" href={link}>
+          {linkTitle}
+        </TextLink>{' '}
+        {' ' + rest}
+      </Note>
+    </div>
+  );
+}

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -1,6 +1,8 @@
 import { ReactElement } from 'react';
 import { Note, TextLink } from '@contentful/forma-36-react-components';
 
+import './Note.css';
+
 export interface INoteProps {
   type: 'primary' | 'positive' | 'negative' | 'warning';
   error: Error;
@@ -17,17 +19,17 @@ export function IxNote({
   const linkTitle = title?.length ? title : link;
 
   return (
-    <div className="ix-note" style={{ marginTop: 25 }}>
+    <div className="ix-note">
       <Note
         noteType={type}
         title={error.name}
         hasCloseButton
         onClose={resetErrorBoundary}
       >
-        {message + ' '}{' '}
+        {message + ' '}
         <TextLink target="window" href={link}>
           {linkTitle}
-        </TextLink>{' '}
+        </TextLink>
         {' ' + rest}
       </Note>
     </div>

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -15,7 +15,6 @@ export function IxNote({
   const [message, _link, ...rest] = error.message.split('$');
   const [link, title] = _link.split('|');
   const linkTitle = title?.length ? title : link;
-  console.log(message, link, ...rest);
 
   return (
     <div className="ix-note" style={{ marginTop: 25 }}>

--- a/src/components/Note/index.ts
+++ b/src/components/Note/index.ts
@@ -1,0 +1,4 @@
+import { IxNote as _Note, INoteProps as _INoteProps } from './Note';
+
+export const Note = _Note;
+export type INoteProps = _INoteProps;

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -1,0 +1,80 @@
+export type NoteType = 'primary' | 'positive' | 'negative' | 'warning';
+export type ErrorType =
+  | `InvalidApiKeyError`
+  | `NoSourcesError`
+  | `NoOriginImagesError`;
+
+const DASHBOARD_URL = 'https://dashboard.imgix.com';
+const APP_CONFIG_URL = 'https://app.contentful.com/deeplink?link=apps';
+
+/*
+* The error messages are split on `$` and then again on `|`. The `$` is used to
+* parse the message's "link" url. The`|` is used to parse the message's "link"
+* title. If the `message` string has no `|` then the `$` is used to parse the
+* message's "link" url and title.
+
+* E.g.
+* `Return to $${APP_CONFIG_URL}|App Config Page$ to enter a valid API key`
+* Will be parsed as: 
+* `Return to https://app.contentful.com/deeplink?link=apps to enter a valid
+* API key`.
+*/
+
+const ERROR_MESSAGES = {
+  InvalidApiKeyError: {
+    message: `Return to $${APP_CONFIG_URL}|App Config Page$ to enter a valid API key`,
+    name: 'Invalid API Key',
+    type: 'negative',
+  },
+  NoSourcesError: {
+    message: `Go to $${DASHBOARD_URL}$ to add an imgix source.`,
+    name: 'You have no imgix sources',
+    type: 'warning',
+  },
+  NoOriginImagesError: {
+    message: `Go to $${DASHBOARD_URL}$ to add an imgix source.`,
+    name: 'This Source has no Origin images',
+    type: 'warning',
+  },
+} as const;
+
+type ErrorMessageType = keyof typeof ERROR_MESSAGES;
+
+/**
+ * @class IxError
+ * @description
+ * This class is used to manage imgix API error messages and warnings. It
+ * extends the builtin `Error` class and adds the `type` property.
+ *
+ * @param {NoteType} type "`InvalidApiKeyError` | `NoSourcesError` | `NoOriginImagesError`"
+ * @param {string} message The error message string.
+ *
+ * @example
+ * const errors = [new IxError()];
+ * console.log(errors[0].name);
+ * // => 'imgix API Error'
+ * console.log(errors[0].message);
+ * // => 'Boom 💥'
+ * console.log(errors[0].type);
+ * // => 'negative'
+ */
+
+export class IxError extends Error {
+  type: NoteType;
+  constructor(type: ErrorType, message?: string) {
+    super(message);
+    this.name =
+      ERROR_MESSAGES[type as ErrorMessageType].name || 'imgix API Error';
+    this.message = message || ERROR_MESSAGES[type as ErrorMessageType].message;
+    this.type = ERROR_MESSAGES[type as ErrorMessageType].type || 'warning';
+  }
+}
+
+export const invalidApiKeyError = (message?: string) =>
+  new IxError('InvalidApiKeyError', message);
+
+export const noSourcesError = (message?: string) =>
+  new IxError('NoSourcesError', message);
+
+export const noOriginImagesError = (message?: string) =>
+  new IxError('NoOriginImagesError', message);


### PR DESCRIPTION
This PR uses the new `Note.tsx` component and the `errors.ts` helper
to display a warning || error fallback UI whenever an IxError occurs.

To do this, the PR creates an `error` slice of state that gets updated
whenever:

- the API key is invalid
- the account has no sources 
- the source has no images. 
 
Each displayed `error` is removed from the state so that
only one `error` can ever be displayed at one time (the oldest error).

This PR also adds another slice of state, `verified`, that comes from
values being written to the contentful SDK. This makes it easier to know
whether or not the API key is valid in the `componentDidMount` lifecycle
hook.

## Future work

The way I'm [currently](https://github.com/imgix/contentful/pull/59#discussion_r675678903) passing URL href and titles to the Note component is a little quirky and could use some iterating.

## Video 📹 

### Invalid API Key

https://user-images.githubusercontent.com/16711614/126812518-c8f73fe9-4cd8-4d56-ade7-40dfde25806c.mp4

### Account has no sources

https://user-images.githubusercontent.com/16711614/126811659-6f45aa62-28f0-48a8-b882-91d1fd6a6067.mp4

### Source has no images
https://user-images.githubusercontent.com/16711614/126811322-dc0da833-3343-4216-9b0d-d510686afc8a.mp4