### PR TITLE
fix(config): update installation instructions copy; disable `Verify` button if input field is empty

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -1,7 +1,14 @@
 .ix-helper-text {
   margin-top: 0.5rem;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-family: -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
   font-size: 0.875rem;
   line-height: 1.5;
   display: block;
@@ -34,3 +41,9 @@
   max-width: 500px;
 }
 
+.ix-config-description > code {
+  padding: 0.5px 4px;
+  border-radius: 3px;
+  background-color: rgb(85, 85, 85);
+  color: orange;
+}

--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -25,10 +25,19 @@
 
 .icon {
   flex: 2;
-  margin-top: 10%;
+  margin-top: 8%;
   margin-left: 10px;
 }
 
 [data-test-id='cf-notification-container'] {
   margin-left: 80px;
 }
+
+.ix-config-container {
+  margin: 80px;
+}
+
+.ix-config-description {
+  max-width: 500px;
+}
+

--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -1,14 +1,7 @@
 .ix-helper-text {
   margin-top: 0.5rem;
-  font-family: -apple-system,
-    BlinkMacSystemFont,
-    Segoe UI,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   font-size: 0.875rem;
   line-height: 1.5;
   display: block;

--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -1,7 +1,14 @@
 .ix-helper-text {
   margin-top: 0.5rem;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-family: -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
   font-size: 0.875rem;
   line-height: 1.5;
   display: block;
@@ -20,4 +27,8 @@
   flex: 2;
   margin-top: 10%;
   margin-left: 10px;
+}
+
+[data-test-id='cf-notification-container'] {
+  margin-left: 80px;
 }

--- a/src/components/ConfigScreen/ConfigScreen.spec.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.spec.tsx
@@ -18,9 +18,7 @@ describe('Config Screen component', () => {
     await mockSdk.app.onConfigure.mock.calls[0][0]();
 
     expect(
-      getByText(
-        'Welcome to your imgix Contentful app. This is your config page.',
-      ),
+      getByText('Getting set up with imgix and Contentful'),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -9,6 +9,7 @@ import {
   Notification,
   Icon,
   Button,
+  TextLink,
 } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
 import ImgixAPI from 'imgix-management-js';
@@ -148,9 +149,36 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     return (
       <Workbench className={css({ margin: '80px' })}>
         <Form>
-          <Heading>App Configuration</Heading>
-          <Paragraph>
-            Welcome to your imgix Contentful app. This is your config page.
+          <Heading>Getting set up with imgix and Contentful</Heading>
+          <Paragraph className="ix-config-description">
+            Welcome to your imgix-contentful configuration page! This
+            integration will allow you to directly interface with your
+            organization's{' '}
+            <TextLink
+              href="https://docs.imgix.com/setup/image-manager"
+              target="_blank"
+            >
+              Image Manager
+            </TextLink>{' '}
+            to select and insert images into your content models.<br></br>
+            <br></br>
+            Before installing this integration to your Contentful workspace, you
+            will need to create an API key from the{' '}
+            <TextLink
+              href="https://dashboard.imgix.com/api-keys"
+              target="_blank"
+            >
+              imgix dashboard
+            </TextLink>
+            . For this integration to work correctly, please ensure that your
+            generated key has the following permissions: <code>Sources</code>{' '}
+            and <code>Image Manager Browse</code>.<br></br>
+            <br></br>
+            After having generated your imgix API key, paste it into the field
+            below and press <code>Verify</code>. If the key is valid, complete
+            set up by pressing <code>Install</code> or <code>Save</code> in the
+            top right hand corner of your screen. If the key is not valid,
+            please confirm your information and try again.
           </Paragraph>
           <div>
             <div className="flex-container">
@@ -174,7 +202,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               )}
             </div>
             <p className="ix-helper-text">
-              Access your API key at{' '}
+              Create and/or access your API key at{' '}
               <a
                 target="_blank"
                 rel="noreferrer"

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -98,7 +98,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
     try {
       await imgix.request('sources');
-      Notification.setPosition('top', { offset: 355 });
+      Notification.setPosition('top', { offset: 595 });
       Notification.success(
         'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
         {
@@ -107,7 +107,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       );
       updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
-      Notification.setPosition('top', { offset: 355 });
+      Notification.setPosition('top', { offset: 595 });
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",
         {

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -11,7 +11,6 @@ import {
   Button,
   TextLink,
 } from '@contentful/forma-36-react-components';
-import { css } from 'emotion';
 import ImgixAPI from 'imgix-management-js';
 
 import './ConfigScreen.css';
@@ -150,7 +149,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
   render() {
     return (
-      <Workbench className={css({ margin: '80px' })}>
+      <Workbench className="ix-config-container">
         <Form>
           <Heading>Getting set up with imgix and Contentful</Heading>
           <Paragraph className="ix-config-description">

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -100,9 +100,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     try {
       await imgix.request('sources');
       Notification.setPosition('top', { offset: 355 });
-      Notification.success('Your API Key was successfully confirmed.', {
-        duration: 3000,
-      });
+      Notification.success(
+        'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
+        {
+          duration: 10000,
+        },
+      );
       updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
       Notification.setPosition('top', { offset: 355 });

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -217,7 +217,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           <Button
             type="submit"
             buttonType="positive"
-            disabled={this.state.parameters.imgixAPIKey?.length == 0}
+            disabled={this.state.parameters.imgixAPIKey?.length === 0}
             onClick={this.onClick}
             loading={this.state.isButtonLoading}
           >

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -98,11 +98,13 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
     try {
       await imgix.request('sources');
+      Notification.setPosition('top', { offset: 355 });
       Notification.success('Your API Key was successfully confirmed.', {
         duration: 3000,
       });
       updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
+      Notification.setPosition('top', { offset: 355 });
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",
         {

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -217,6 +217,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           <Button
             type="submit"
             buttonType="positive"
+            disabled={this.state.parameters.imgixAPIKey?.length == 0}
             onClick={this.onClick}
             loading={this.state.isButtonLoading}
           >

--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -13,7 +13,3 @@
     padding: 40px 64px;
   }
 }
-
-[data-test-id='cf-ui-notification'] {
-  margin-bottom: 40vh;
-}

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -26,7 +26,7 @@ export default class Field extends Component<FieldProps, FieldState> {
   openDialog = () => {
     this.props.sdk.dialogs
       .openCurrentApp({
-        width: 'fullWidth',
+        width: 1200,
         minHeight: 1200,
         position: 'top',
         shouldCloseOnOverlayClick: true,

--- a/src/components/Gallery/ImagePagination.css
+++ b/src/components/Gallery/ImagePagination.css
@@ -15,7 +15,19 @@
   border-radius: 0;
 }
 
+.ix-pagination-dropdown {
+  width: 133px;
+}
+
+.ix-pagination-dropdown > li > button > span {
+  text-align: center;
+}
+
 .ix-pagination-nextButton {
   direction: rtl;
   border-radius: 0 8px 8px 0;
+}
+
+[data-test-id='cf-ui-dropdown-container'] {
+  border-radius: 0 0 8px 8px;
 }

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -69,7 +69,7 @@ export function ImagePagination({
           </Button>
         }
       >
-        <DropdownList maxHeight={111}>
+        <DropdownList className="ix-pagination-dropdown" maxHeight={111}>
           {/* a maxHeight of 111 is the minimum height to fit 3 entries without
           needing to scroll */}
           {[...Array(pageInfo.totalPageCount)].map((_, _pageIndex) => {

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -3,7 +3,7 @@ import {
   Button,
   Dropdown,
   DropdownList,
-  DropdownListItem
+  DropdownListItem,
 } from '@contentful/forma-36-react-components';
 
 import { PageProps } from '../Dialog';


### PR DESCRIPTION
This PR makes adjustments to the App Config copy as per design feedback.

@marco-salcedo, I could use some feedback/thoughts on the following:
- There are two inline `<code>` blocks that could probably use some styling to make them pop out a bit more. Curious if you have any suggestions on what they should specifically be
- With all the new copy added, it looks like the verify Notification is now overlapping with the rest of the page (see video below). I might need your help on realigning it so that they  don't overlap.

https://user-images.githubusercontent.com/15919091/126913988-3c7bd678-f858-4244-8b8f-1409e86d2268.mov

Here is the same page after merging #60 into this branch:

https://user-images.githubusercontent.com/15919091/127205736-a890bc11-c4b4-4136-8261-4ea17c619380.mov

