### PR TITLE
fix(config): change text highlighting to guide user through installation

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -34,9 +34,24 @@
   max-width: 500px;
 }
 
-.ix-config-description > code {
+code {
   padding: 0.5px 4px;
   border-radius: 3px;
-  background-color: rgb(85, 85, 85);
-  color: orange;
+  color: rgba(255, 255, 255, 0.842);
+}
+
+code.ix-config-description-permissions {
+  background-color: #1b273a;
+}
+
+code.ix-config-description-blue-buttons {
+  background-color: #036fe3;
+}
+
+code.ix-config-description-green-button {
+  background-color: #008539;
+}
+
+.ix-config-description-list {
+  color: #414d63;
 }

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -10,6 +10,8 @@ import {
   Icon,
   Button,
   TextLink,
+  List,
+  ListItem,
 } from '@contentful/forma-36-react-components';
 import ImgixAPI from 'imgix-management-js';
 
@@ -150,9 +152,9 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   render() {
     return (
       <Workbench className="ix-config-container">
-        <Form>
+        <Form className="ix-config-description">
           <Heading>Getting set up with imgix and Contentful</Heading>
-          <Paragraph className="ix-config-description">
+          <Paragraph>
             Welcome to your imgix-contentful configuration page! This
             integration will allow you to directly interface with your
             organization's{' '}
@@ -173,15 +175,33 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               imgix dashboard
             </TextLink>
             . For this integration to work correctly, please ensure that your
-            generated key has the following permissions: <code>Sources</code>{' '}
-            and <code>Image Manager Browse</code>.<br></br>
+            generated key has the following permissions:{' '}
+            <code className="ix-config-description-permissions">Sources</code>{' '}
+            and{' '}
+            <code className="ix-config-description-permissions">
+              Image Manager Browse
+            </code>
+            .<br></br>
             <br></br>
             After having generated your imgix API key, paste it into the field
-            below and press <code>Verify</code>. If the key is valid, complete
-            set up by pressing <code>Install</code> or <code>Save</code> in the
-            top right hand corner of your screen. If the key is not valid,
-            please confirm your information and try again.
+            below and press{' '}
+            <code className="ix-config-description-green-button">Verify</code>.
           </Paragraph>
+          <List className="ix-config-description-list">
+            <ListItem>
+              If the key is valid, complete set up by pressing{' '}
+              <code className="ix-config-description-blue-buttons">
+                Install
+              </code>{' '}
+              or{' '}
+              <code className="ix-config-description-blue-buttons">Save</code>{' '}
+              in the top right hand corner of the screen.
+            </ListItem>
+            <ListItem>
+              If the key is not valid, please confirm your information and try
+              again.
+            </ListItem>
+          </List>
           <div>
             <div className="flex-container">
               <div className="flex-child">

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -100,7 +100,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
     try {
       await imgix.request('sources');
-      Notification.setPosition('top', { offset: 595 });
+      Notification.setPosition('top', { offset: 645 });
       Notification.success(
         'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
         {
@@ -109,7 +109,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       );
       updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
-      Notification.setPosition('top', { offset: 595 });
+      Notification.setPosition('top', { offset: 650 });
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",
         {


### PR DESCRIPTION
This PR incorporates some second-round design feedback into the App Config page:

- Selectively change certain `<code>` background colors to help the user more-easily navigate the installation flow
- Minor refactoring of the `<code>` styling
- Moving a portion of the installation instructions into an unordered list, as per request
- Adjusting the `Notification` height offset to account for vertical spacing shift due to the aforementioned changes

https://user-images.githubusercontent.com/15919091/127239386-3996259d-e66f-4f9c-8b01-653063e4471a.mov