### PR TITLE
fix: implement internal/design feedback

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -237,7 +237,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           <Button
             type="submit"
             buttonType="positive"
-            disabled={this.state.parameters.imgixAPIKey?.length === 0}
+            disabled={!this.state.parameters.imgixAPIKey?.length}
             onClick={this.onClick}
             /*
             ** TODO: uncomment out once the following forma36 bug is addressed

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -240,9 +240,9 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             disabled={!this.state.parameters.imgixAPIKey?.length}
             onClick={this.onClick}
             /*
-            ** TODO: uncomment out once the following forma36 bug is addressed
-            ** https://github.com/contentful/forma-36/issues/895
-            */
+             ** TODO: uncomment out once the following forma36 bug is addressed
+             ** https://github.com/contentful/forma-36/issues/895
+             */
             // loading={this.state.isButtonLoading}
           >
             Verify

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -239,7 +239,11 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             buttonType="positive"
             disabled={this.state.parameters.imgixAPIKey?.length === 0}
             onClick={this.onClick}
-            loading={this.state.isButtonLoading}
+            /*
+            ** TODO: uncomment out once the following forma36 bug is addressed
+            ** https://github.com/contentful/forma-36/issues/895
+            */
+            // loading={this.state.isButtonLoading}
           >
             Verify
           </Button>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -41,6 +41,10 @@ export type SourceProps = {
   domain: string;
 };
 
+type AppInvocationParameters = {
+  selectedImage: string;
+}
+
 export default class Dialog extends Component<DialogProps, DialogState> {
   constructor(props: DialogProps) {
     super(props);
@@ -159,10 +163,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   render() {
     const { selectedSource, allSources, page, imgix } = this.state;
     const sdk = this.props.sdk;
+    const selectedImage = (this.props.sdk.parameters.invocation as AppInvocationParameters)?.selectedImage;
 
     return (
       <div className="ix-container">
-        <DialogHeader handleClose={this.props.sdk.close} />
+        <DialogHeader handleClose={sdk.close} selectedImage={selectedImage} />
         <SourceSelect
           selectedSource={selectedSource}
           allSources={allSources}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -43,15 +43,15 @@ export type SourceProps = {
 
 type AppInvocationParameters = {
   selectedImage: string;
-}
+};
 
 export default class Dialog extends Component<DialogProps, DialogState> {
   constructor(props: DialogProps) {
     super(props);
 
-    const installationParameters =
-      (props.sdk.parameters.installation as AppInstallationParameters);
-    const apiKey = installationParameters.imgixAPIKey || ''
+    const installationParameters = props.sdk.parameters
+      .installation as AppInstallationParameters;
+    const apiKey = installationParameters.imgixAPIKey || '';
     const verified = !!installationParameters.successfullyVerified;
     const imgix = new ImgixAPI({
       apiKey,
@@ -163,7 +163,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   render() {
     const { selectedSource, allSources, page, imgix } = this.state;
     const sdk = this.props.sdk;
-    const selectedImage = (this.props.sdk.parameters.invocation as AppInvocationParameters)?.selectedImage;
+    const selectedImage = (
+      this.props.sdk.parameters.invocation as AppInvocationParameters
+    )?.selectedImage;
 
     return (
       <div className="ix-container">

--- a/src/components/Dialog/DialogHeader.tsx
+++ b/src/components/Dialog/DialogHeader.tsx
@@ -3,11 +3,14 @@ import { Button, Paragraph } from '@contentful/forma-36-react-components';
 
 import './DialogHeader.css';
 
-interface Props {
-  handleClose: () => void;
+type selectedImageType = string | undefined;
+
+interface DialogHeaderProps {
+  handleClose: (selectedImage: selectedImageType) => void;
+  selectedImage: selectedImageType;
 }
 
-export function DialogHeader({ handleClose }: Props): ReactElement {
+export function DialogHeader({ handleClose, selectedImage }: DialogHeaderProps): ReactElement {
   return (
     <div className="ix-header-container">
       <Paragraph className="ix-title">imgix Source:</Paragraph>
@@ -16,7 +19,7 @@ export function DialogHeader({ handleClose }: Props): ReactElement {
         icon="Close"
         buttonType="naked"
         size="small"
-        onClick={() => handleClose()}
+        onClick={() => handleClose(selectedImage)}
       ></Button>
     </div>
   );

--- a/src/components/Dialog/DialogHeader.tsx
+++ b/src/components/Dialog/DialogHeader.tsx
@@ -10,7 +10,10 @@ interface DialogHeaderProps {
   selectedImage: selectedImageType;
 }
 
-export function DialogHeader({ handleClose, selectedImage }: DialogHeaderProps): ReactElement {
+export function DialogHeader({
+  handleClose,
+  selectedImage,
+}: DialogHeaderProps): ReactElement {
   return (
     <div className="ix-header-container">
       <Paragraph className="ix-title">imgix Source:</Paragraph>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -33,7 +33,7 @@ export default class Field extends Component<FieldProps, FieldState> {
         allowHeightOverflow: true,
         parameters: {
           selectedImage: this.state.imagePath,
-        }
+        },
       })
       .then((imagePath) =>
         this.setState({ imagePath }, () =>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -31,6 +31,9 @@ export default class Field extends Component<FieldProps, FieldState> {
         position: 'top',
         shouldCloseOnOverlayClick: true,
         allowHeightOverflow: true,
+        parameters: {
+          selectedImage: this.state.imagePath,
+        }
       })
       .then((imagePath) =>
         this.setState({ imagePath }, () =>

--- a/src/components/Field/FieldImagePreview.css
+++ b/src/components/Field/FieldImagePreview.css
@@ -5,6 +5,7 @@
   grid-column-gap: 0px;
   grid-row-gap: 16px;
   width: 230px;
+  max-height: 311px;
 }
 
 .ix-field-image-preview-buttons {


### PR DESCRIPTION
This PR implements a few changes/fixes based on internal feedback. I will cover each one individually in detail below:

(Temporarily) Remove the `Verify` button's loading spinner
----
There appears to be a bug in forma36's button that causes the loading spinner to show even if the `loading` flag is set to false (details in https://github.com/contentful/forma-36/issues/895). Until this issue is resolved we are going to remove this interaction as it might be confusing for users when attempting to verify their API key.
Reproduction of this issue:

https://user-images.githubusercontent.com/15919091/127609514-7e8b37ea-c7f1-4e46-ac6d-64cbceb33d23.mov

<br><br>
Disable `Verify` button if input field is empty or `undefined`
----
Previously, we only disabled the `Verify` button if the input field length was 0. However, there is an edge case where upon initially installing the integration, this condition was not met.

**Before**

https://user-images.githubusercontent.com/15919091/127609942-8123a84a-6ac1-4a52-b8bb-0ecd845564d4.mov

**After**

https://user-images.githubusercontent.com/15919091/127609954-f73f6b3d-2ade-4da0-b22c-701ba087841e.mov

<br><br>
Set a `max-height` on FieldImagePreview container
----
Without this value set, the user is able to scroll when hovering over the component as the default container height adds extra vertical spacing.

**Before**

https://user-images.githubusercontent.com/15919091/127611013-29286012-d4ba-4091-a9c4-d87108dcef77.mov

**After**

https://user-images.githubusercontent.com/15919091/127611037-b826ec14-82dc-40a7-959b-3dbdb88f1521.mov

<br><br>
Do not clear current image selection if user closes the Dialog
----
The Dialog close button invokes the `sdk.close()` method. When no parameters are passed to it, this will clear any previously-selected image from the stored Field value. This commit passes along any selected image all the way down to the DialogHeader, passing it as a value to `sdk.close()`. This will, in effect, keep any selected image if one already exists.

**Before**

https://user-images.githubusercontent.com/15919091/127611544-a5439533-6822-445a-81ba-4af5c7678c75.mov

**After**

https://user-images.githubusercontent.com/15919091/127611568-d5c23408-1d03-4fa9-9494-8f667a69dbed.mov
