### PR TITLE
chore: update note copy and store API key validity in state on config change

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -65,6 +65,9 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     // or "Save" in the configuration screen.
     // for more details see https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/#register-an-app-configuration-hook
 
+    // ensure the API key is validated
+    await this.verifyAPIKey();
+
     // Get current the state of EditorInterface and other entities
     // related to this app installation
     const currentState = await this.props.sdk.app.getCurrentState();

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -141,6 +141,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     this.setState({ selectedSource: source });
   };
 
+  resetNErrors = (n: number = 1) => {
+    this.setState({ errors: this.state.errors.slice(n) });
+  };
+
   async componentDidMount() {
     // If the API key is not valid do not attempt to load sources
     if (!this.state.verified) {
@@ -174,6 +178,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           selectedSource={selectedSource}
           allSources={allSources}
           setSource={this.setSelectedSource}
+          resetErrors={() => this.resetNErrors(this.state.errors.length)}
         />
         <ImageGallery
           selectedSource={selectedSource}
@@ -188,9 +193,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           <Note
             error={this.state.errors[0]}
             type={this.state.errors[0].type}
-            resetErrorBoundary={() =>
-              this.setState({ errors: this.state.errors.slice(1) })
-            }
+            resetErrorBoundary={this.resetNErrors}
           />
         )}
       </div>

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -15,7 +15,7 @@ export function IxNote({
   resetErrorBoundary,
 }: INoteProps): ReactElement {
   const [message, _link, ...rest] = error.message.split('$');
-  const [link, title] = _link.split('|');
+  const [link, title] = _link?.split('|') || ['', ''];
   const linkTitle = title?.length ? title : link;
 
   return (

--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -13,17 +13,20 @@ interface Props {
   selectedSource: Partial<SourceProps>;
   allSources: Array<any>;
   setSource: Function;
+  resetErrors: Function;
 }
 
 export function SourceSelectDropdown({
   selectedSource,
   allSources,
   setSource,
+  resetErrors,
 }: Props): ReactElement {
   const [isOpen, setOpen] = React.useState(false);
   const handleClick = (source: SourceProps) => {
     setOpen(false);
     setSource(source);
+    resetErrors();
   };
 
   return (

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -32,7 +32,7 @@ const ERROR_MESSAGES = {
     type: 'warning',
   },
   NoOriginImagesError: {
-    message: `Go to $${DASHBOARD_URL}$ to add Origin images to this Source.`,
+    message: `Go to $${DASHBOARD_URL + '/sources'}$ to add Origin images to this Source.`,
     name: 'This Source has no Origin images',
     type: 'warning',
   },

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -5,7 +5,6 @@ export type ErrorType =
   | `NoOriginImagesError`;
 
 const DASHBOARD_URL = 'https://dashboard.imgix.com';
-const APP_CONFIG_URL = 'https://app.contentful.com/deeplink?link=apps';
 
 /*
 * The error messages are split on `$` and then again on `|`. The `$` is used to
@@ -14,7 +13,7 @@ const APP_CONFIG_URL = 'https://app.contentful.com/deeplink?link=apps';
 * message's "link" url and title.
 
 * E.g.
-* `Return to $${APP_CONFIG_URL}|App Config Page$ to enter a valid API key`
+* `Return to $${APP_CONFIG_URL}|Configuration Page$ to enter a valid API key`
 * Will be parsed as: 
 * `Return to https://app.contentful.com/deeplink?link=apps to enter a valid
 * API key`.
@@ -22,17 +21,18 @@ const APP_CONFIG_URL = 'https://app.contentful.com/deeplink?link=apps';
 
 const ERROR_MESSAGES = {
   InvalidApiKeyError: {
-    message: `Return to $${APP_CONFIG_URL}|App Config Page$ to enter a valid API key`,
+    message: `Return to the Configuration Page to enter a valid API Key or 
+    contact your system administrator.`,
     name: 'Invalid API Key',
     type: 'negative',
   },
   NoSourcesError: {
-    message: `Go to $${DASHBOARD_URL}$ to add an imgix source.`,
-    name: 'You have no imgix sources',
+    message: `Go to $${DASHBOARD_URL + '/sources'}$ to add an imgix Source.`,
+    name: 'You have no imgix Sources',
     type: 'warning',
   },
   NoOriginImagesError: {
-    message: `Go to $${DASHBOARD_URL}$ to add an imgix source.`,
+    message: `Go to $${DASHBOARD_URL}$ to add Origin images to this Source.`,
     name: 'This Source has no Origin images',
     type: 'warning',
   },


### PR DESCRIPTION
- updates the Error message copy for APIKey and, Source, and Origin errors
- add a `resetNErrors()` function that clears `n` errors from state
- clears the `errors` from the state when a different source is selected
- stores the API key's validity to state any time the application configuration is changed.
- fixes an issue where the Note component was parsing Error messages incorrectly when there was no URL present