### PR TITLE
fix: debounce any API requests to prevent users from getting ratelimited

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "contentful-ui-extensions-sdk": "^3.31.0",
         "cross-env": "^7.0.3",
         "imgix-management-js": "^1.2.1",
+        "lodash.debounce": "^4.0.8",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-imgix": "^9.2.0",
@@ -30,6 +31,7 @@
         "typescript": "^4.1.3"
       },
       "devDependencies": {
+        "@types/lodash.debounce": "^4.0.6",
         "@types/react-imgix": "9.0.4",
         "prettier": "2.3.2"
       }
@@ -3406,6 +3408,21 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.171",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -24057,6 +24074,21 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "@types/lodash": {
+      "version": "4.14.171",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "contentful-ui-extensions-sdk": "^3.31.0",
     "cross-env": "^7.0.3",
     "imgix-management-js": "^1.2.1",
+    "lodash.debounce": "^4.0.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-imgix": "^9.2.0",
@@ -47,6 +48,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash.debounce": "^4.0.6",
     "@types/react-imgix": "9.0.4",
     "prettier": "2.3.2"
   }

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -14,6 +14,7 @@ import {
   ListItem,
 } from '@contentful/forma-36-react-components';
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import debounce from 'lodash.debounce';
 
 import './ConfigScreen.css';
 
@@ -150,6 +151,10 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     }
   };
 
+  debounceOnClick = debounce(this.onClick, 1000, {
+    leading: true,
+  });
+
   getAPIKey = async () => {
     return this.props.sdk.app
       .getParameters()
@@ -247,12 +252,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             type="submit"
             buttonType="positive"
             disabled={!this.state.parameters.imgixAPIKey?.length}
-            onClick={this.onClick}
             /*
              ** TODO: uncomment out once the following forma36 bug is addressed
              ** https://github.com/contentful/forma-36/issues/895
              */
             // loading={this.state.isButtonLoading}
+            onClick={this.debounceOnClick}
           >
             Verify
           </Button>

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -13,7 +13,7 @@ import {
   List,
   ListItem,
 } from '@contentful/forma-36-react-components';
-import ImgixAPI from 'imgix-management-js';
+import ImgixAPI, { APIError } from 'imgix-management-js';
 
 import './ConfigScreen.css';
 
@@ -112,6 +112,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       );
       updatedInstallationParameters.successfullyVerified = true;
     } catch (error) {
+      // APIError will emit more helpful data for debugging
+      if (error instanceof APIError) {
+        console.error(error.toString());
+      } else {
+        console.error(error);
+      }
       Notification.setPosition('top', { offset: 650 });
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,8 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
+
 import ImgixAPI, { APIError } from 'imgix-management-js';
+import { debounce } from 'lodash';
 
 import { DialogHeader } from './';
 import { AppInstallationParameters } from '../ConfigScreen/';
@@ -135,7 +137,13 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   };
 
   handlePageChange = (newPageIndex: number) =>
-    this.setState({ page: { ...this.state.page, currentIndex: newPageIndex } });
+    this.setState({
+      page: { ...this.state.page, currentIndex: newPageIndex },
+    });
+
+  debounceHandlePageChange = debounce(this.handlePageChange, 1000, {
+    leading: true,
+  });
 
   setSelectedSource = (source: SourceProps) => {
     this.setState({ selectedSource: source });
@@ -186,7 +194,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           sdk={sdk}
           getTotalImageCount={this.handleTotalImageCount}
           pageInfo={page}
-          changePage={this.handlePageChange}
+          changePage={this.debounceHandlePageChange}
         />
         {/* { UI Error fallback } */}
         {this.state.errors.length > 0 && (

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,5 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
-
 import ImgixAPI, { APIError } from 'imgix-management-js';
 import { debounce } from 'lodash';
 

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
-
 import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { debounce } from 'lodash';
 
 import { FieldImagePreview, FieldPrompt } from './';
 
@@ -41,6 +41,7 @@ export default class Field extends Component<FieldProps, FieldState> {
         ),
       );
   };
+  debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });
 
   clearSelection = () => {
     this.setState({ imagePath: undefined }, () =>
@@ -54,7 +55,7 @@ export default class Field extends Component<FieldProps, FieldState> {
       return (
         <FieldImagePreview
           imagePath={this.state.imagePath}
-          openDialog={this.openDialog}
+          openDialog={this.debounceOpenDialog}
           updateHeight={updateHeightHandler}
           clearSelection={this.clearSelection}
         />
@@ -62,7 +63,7 @@ export default class Field extends Component<FieldProps, FieldState> {
     } else {
       return (
         <FieldPrompt
-          openDialog={this.openDialog}
+          openDialog={this.debounceOpenDialog}
           updateHeight={updateHeightHandler}
         />
       );

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -5,7 +5,6 @@ import {
   DropdownList,
   DropdownListItem,
 } from '@contentful/forma-36-react-components';
-import { debounce } from 'lodash';
 
 import { PageProps } from '../Dialog';
 
@@ -27,20 +26,20 @@ export function ImagePagination({
     setOpen(false);
     changePage(newPageIndex);
   };
+
   const paginateForward = () => {
     const nextPage = pageInfo.currentIndex + 1;
     if (nextPage < pageInfo.totalPageCount) {
       changePage(nextPage);
     }
   };
-  const debouncePaginateForward = debounce(paginateForward, 1000);
+
   const paginateBackward = () => {
     const prevPage = pageInfo.currentIndex - 1;
     if (prevPage >= 0) {
       changePage(prevPage);
     }
   };
-  const debouncePaginateBackward = debounce(paginateBackward, 1000);
 
   if (sourceId === undefined) {
     // return react fragment if no sourceId is provided
@@ -53,7 +52,7 @@ export function ImagePagination({
         buttonType="muted"
         icon="ChevronLeft"
         size="small"
-        onClick={debouncePaginateBackward}
+        onClick={paginateBackward}
       >
         Prev Page
       </Button>
@@ -93,7 +92,7 @@ export function ImagePagination({
         buttonType="muted"
         icon="ChevronRight"
         size="small"
-        onClick={debouncePaginateForward}
+        onClick={paginateForward}
       >
         Next Page
       </Button>

--- a/src/components/Gallery/ImagePagination.tsx
+++ b/src/components/Gallery/ImagePagination.tsx
@@ -5,6 +5,7 @@ import {
   DropdownList,
   DropdownListItem,
 } from '@contentful/forma-36-react-components';
+import { debounce } from 'lodash';
 
 import { PageProps } from '../Dialog';
 
@@ -32,12 +33,14 @@ export function ImagePagination({
       changePage(nextPage);
     }
   };
+  const debouncePaginateForward = debounce(paginateForward, 1000);
   const paginateBackward = () => {
     const prevPage = pageInfo.currentIndex - 1;
     if (prevPage >= 0) {
       changePage(prevPage);
     }
   };
+  const debouncePaginateBackward = debounce(paginateBackward, 1000);
 
   if (sourceId === undefined) {
     // return react fragment if no sourceId is provided
@@ -50,7 +53,7 @@ export function ImagePagination({
         buttonType="muted"
         icon="ChevronLeft"
         size="small"
-        onClick={() => paginateBackward()}
+        onClick={debouncePaginateBackward}
       >
         Prev Page
       </Button>
@@ -90,7 +93,7 @@ export function ImagePagination({
         buttonType="muted"
         icon="ChevronRight"
         size="small"
-        onClick={() => paginateForward()}
+        onClick={debouncePaginateForward}
       >
         Next Page
       </Button>


### PR DESCRIPTION
This PR adds guardrails throughout the intergration (with the help of `lodash.debounce`) to prevent users from accidentally hitting API ratelimits. This can happen when/if a user rapidly presses certain UI elements that are tied to API calls. Because the imgix API has a ratelimit, this can cause some unusual reactions for unaware users. These changes hope to add to the user experience when interacting with this application. See demonstration below:

**Before**

https://user-images.githubusercontent.com/15919091/127715367-ddf232c8-e3ed-480f-9d25-893a4cb76f94.mov

**After**

https://user-images.githubusercontent.com/15919091/127715394-f5c7bcd0-9979-46ff-b62a-d2f9fda681e0.mov


Address feedback left on #35 