### PR TITLE
feat(field)!: export image src within JSON object

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -19,7 +19,7 @@ export default class Field extends Component<FieldProps, FieldState> {
     const storedValue = this.props.sdk.field.getValue();
 
     this.state = {
-      imagePath: storedValue || '',
+      imagePath: storedValue?.src || '',
     };
   }
 
@@ -37,7 +37,7 @@ export default class Field extends Component<FieldProps, FieldState> {
       })
       .then((imagePath) =>
         this.setState({ imagePath }, () =>
-          this.props.sdk.field.setValue(imagePath),
+          this.props.sdk.field.setValue({ src: imagePath }),
         ),
       );
   };


### PR DESCRIPTION
This commit introduces a breaking change to how this integration works. Previously, the URL of the selected image was exported as a String via the ctf API. We have since decided that for future flexibility, this value should be exported as a value in a JSON object.
This results in a few (minor) changes in terms of user interactions:

- The integration can only be enabled/used on JSON object fields within a content model, as opposed to short text
- Developers querying the Contentful API for this value will need to query for the `src` key from the resulting response