### PR TITLE
feat(config): reenable loading spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/field-editor-single-line": "^0.15.0",
         "@contentful/field-editor-test-utils": "^0.17.0",
         "@contentful/forma-36-fcss": "^0.3.0",
-        "@contentful/forma-36-react-components": "^3.74.1",
+        "@contentful/forma-36-react-components": "^3.97.1",
         "@contentful/forma-36-tokens": "^0.11.0",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@contentful/field-editor-single-line": "^0.15.0",
     "@contentful/field-editor-test-utils": "^0.17.0",
     "@contentful/forma-36-fcss": "^0.3.0",
-    "@contentful/forma-36-react-components": "^3.74.1",
+    "@contentful/forma-36-react-components": "^3.97.1",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^12.0.0",

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -252,11 +252,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             type="submit"
             buttonType="positive"
             disabled={!this.state.parameters.imgixAPIKey?.length}
-            /*
-             ** TODO: uncomment out once the following forma36 bug is addressed
-             ** https://github.com/contentful/forma-36/issues/895
-             */
-            // loading={this.state.isButtonLoading}
+            loading={this.state.isButtonLoading}
             onClick={this.debounceOnClick}
           >
             Verify


### PR DESCRIPTION
This commit rolls back 749fcc3, which temporarily disabled the loading spinner on the Verify button due to a bug. Now that the bug is fixed, we can safely enable it again.