### PR TITLE
feat: allow users to select fields to add imgix-contentful to

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.css
+++ b/src/components/ConfigScreen/ConfigScreen.css
@@ -1,14 +1,7 @@
 .ix-helper-text {
   margin-top: 0.5rem;
-  font-family: -apple-system,
-    BlinkMacSystemFont,
-    Segoe UI,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   font-size: 0.875rem;
   line-height: 1.5;
   display: block;

--- a/src/components/ConfigScreen/ConfigScreen.spec.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.spec.tsx
@@ -10,6 +10,14 @@ describe('Config Screen component', () => {
         setReady: jest.fn(),
         getCurrentState: jest.fn(),
       },
+      space: {
+        getEditorInterfaces: jest.fn().mockReturnValueOnce({
+          items: [],
+        }),
+      },
+      ids: {
+        app: 'test-app-id',
+      },
     };
     const { getByText } = render(<ConfigScreen sdk={mockSdk} />);
 

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -385,13 +385,19 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               </Paragraph>
               <br></br>
               {this.state.contentTypes.map(
-                ({ contentName, compatibleFields }: ContentType, contentIndex) => (
+                (
+                  { contentName, compatibleFields }: ContentType,
+                  contentIndex,
+                ) => (
                   <div>
                     <Subheading>{contentName}</Subheading>
                     <br></br>
                     <Form>
                       {compatibleFields.map(
-                        ({ fieldId, fieldName, enabled }: CompatibleField, fieldIndex) => (
+                        (
+                          { fieldId, fieldName, enabled }: CompatibleField,
+                          fieldIndex,
+                        ) => (
                           <CheckboxField
                             labelText={fieldName}
                             id={fieldId}

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -12,6 +12,8 @@ import {
   TextLink,
   List,
   ListItem,
+  CheckboxField,
+  Subheading,
 } from '@contentful/forma-36-react-components';
 import ImgixAPI, { APIError } from 'imgix-management-js';
 import debounce from 'lodash.debounce';
@@ -339,6 +341,45 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           >
             Verify
           </Button>
+          {this.state.contentTypes.length > 0 && (
+            <div>
+              <hr></hr>
+              <Heading>Assign to fields</Heading>
+              <Paragraph>
+                This app can only be used with <strong>JSON object</strong>{' '}
+                fields. Select which JSON fields you’d like to enable for this
+                app.
+              </Paragraph>
+              {this.state.contentTypes.map(
+                ({ contentName, mergedFields }: ContentType, contentIndex) => (
+                  <div>
+                    <Subheading>{contentName}</Subheading>
+                    <br></br>
+                    <Form>
+                      {mergedFields.map(
+                        ({ fieldId, fieldName, enabled }: CompatibleField, fieldIndex) => (
+                          <CheckboxField
+                            labelText={fieldName}
+                            id={fieldId}
+                            helpText={`FieldId: ${fieldId}`}
+                            checked={enabled}
+                            onChange={() => {
+                              // flip the enabled value of the selected field
+                              const changedState = { ...this.state };
+                              changedState.contentTypes[
+                                contentIndex
+                              ].mergedFields[fieldIndex].enabled = !enabled;
+                              this.setState(changedState);
+                            }}
+                          />
+                        ),
+                      )}
+                    </Form>
+                  </div>
+                ),
+              )}
+            </div>
+          )}
         </Form>
         <div className="ix-config-footer">
           <img className="ix-config-footerLogo" src="https://assets.imgix.net/sdk-imgix-logo.svg" alt="App logo" />

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -34,7 +34,7 @@ interface CompatibleField {
 interface ContentType {
   contentName: string;
   contentId: string;
-  mergedFields: CompatibleField[];
+  compatibleFields: CompatibleField[];
 }
 
 interface ConfigProps {
@@ -125,15 +125,15 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         const contentType: any = await space.getContentType(contentId);
 
         if (contentType.fields) {
-          const mergedFields = getCompatibleFields(
+          const compatibleFields = getCompatibleFields(
             ei.controls,
             contentType.fields,
           );
-          if (mergedFields.length > 0) {
+          if (compatibleFields.length > 0) {
             return {
               contentName: contentType.name as string,
               contentId: contentId as string,
-              mergedFields,
+              compatibleFields,
             };
           }
         }
@@ -174,16 +174,16 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     const currentState = await this.props.sdk.app.getCurrentState();
 
     const EditorInterface = this.state.contentTypes.reduce(
-      (editorInterface: any, { contentId, mergedFields }: ContentType) => {
+      (editorInterface: any, { contentId, compatibleFields }: ContentType) => {
         if (
-          mergedFields.length > 0 &&
-          mergedFields.some((field) => field.enabled)
+          compatibleFields.length > 0 &&
+          compatibleFields.some((field) => field.enabled)
         ) {
           editorInterface[contentId] = {
             controls: [],
           };
 
-          mergedFields.map(({ fieldId, enabled }: CompatibleField) => {
+          compatibleFields.map(({ fieldId, enabled }: CompatibleField) => {
             if (enabled) {
               editorInterface[contentId].controls.push({ fieldId });
             }
@@ -383,13 +383,14 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                 fields. Select which JSON fields you’d like to enable for this
                 app.
               </Paragraph>
+              <br></br>
               {this.state.contentTypes.map(
-                ({ contentName, mergedFields }: ContentType, contentIndex) => (
+                ({ contentName, compatibleFields }: ContentType, contentIndex) => (
                   <div>
                     <Subheading>{contentName}</Subheading>
                     <br></br>
                     <Form>
-                      {mergedFields.map(
+                      {compatibleFields.map(
                         ({ fieldId, fieldName, enabled }: CompatibleField, fieldIndex) => (
                           <CheckboxField
                             labelText={fieldName}
@@ -401,7 +402,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                               const changedState = { ...this.state };
                               changedState.contentTypes[
                                 contentIndex
-                              ].mergedFields[fieldIndex].enabled = !enabled;
+                              ].compatibleFields[fieldIndex].enabled = !enabled;
                               this.setState(changedState);
                             }}
                           />

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -65,14 +65,15 @@ export default class Config extends Component<ConfigProps, ConfigState> {
   async componentDidMount() {
     // Get current parameters of the app.
     // If the app is not installed yet, `parameters` will be `null`.
-    const parameters: AppInstallationParameters | null =
-      await this.props.sdk.app.getParameters();
+    const parameters: AppInstallationParameters =
+      (await this.props.sdk.app.getParameters()) || {};
 
     // Forcing the type here to include any[] as Promise.all can return `undefined`
     // but we will filter all values out before returning the final array
     const contentTypes: (ContentType | any)[] =
       await this.getContentTypesWithCompatibleFields();
 
+    this.setState({ parameters, contentTypes }, async () => {
       // Once preparation has finished, call `setReady` to hide
       // the loading screen and present the app to a user.
       this.props.sdk.app.setReady();

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -218,7 +218,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
     try {
       await imgix.request('sources');
-      Notification.setPosition('top', { offset: 490 });
+      Notification.setPosition('top', { offset: 650 });
       Notification.success(
         'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
         {
@@ -234,7 +234,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       } else {
         console.error(error);
       }
-      Notification.setPosition('top', { offset: 490 });
+      Notification.setPosition('top', { offset: 650 });
       Notification.error(
         "We couldn't verify this API Key. Confirm your details and try again.",
         {

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -123,7 +123,6 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       editorInterfaces.items.map(async (ei: any) => {
         const contentId = ei.sys?.contentType?.sys?.id;
         const contentType: any = await space.getContentType(contentId);
-
         if (contentType.fields) {
           const compatibleFields = getCompatibleFields(
             ei.controls,
@@ -224,7 +223,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
         {
           duration: 10000,
-          id: 'ix-config-notification'
+          id: 'ix-config-notification',
         },
       );
       updatedInstallationParameters.successfullyVerified = true;
@@ -240,7 +239,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         "We couldn't verify this API Key. Confirm your details and try again.",
         {
           duration: 3000,
-          id: 'ix-config-notification'
+          id: 'ix-config-notification',
         },
       );
       updatedInstallationParameters.successfullyVerified = false;
@@ -423,7 +422,11 @@ export default class Config extends Component<ConfigProps, ConfigState> {
           )}
         </Form>
         <div className="ix-config-footer">
-          <img className="ix-config-footerLogo" src="https://assets.imgix.net/sdk-imgix-logo.svg" alt="App logo" />
+          <img
+            className="ix-config-footerLogo"
+            src="https://assets.imgix.net/sdk-imgix-logo.svg"
+            alt="App logo"
+          />
         </div>
       </Workbench>
     );

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -23,6 +23,18 @@ export interface AppInstallationParameters {
   successfullyVerified?: boolean;
 }
 
+interface CompatibleField {
+  fieldId: string;
+  fieldName: string;
+  enabled: boolean;
+}
+
+interface ContentType {
+  contentName: string;
+  contentId: string;
+  mergedFields: CompatibleField[];
+}
+
 interface ConfigProps {
   sdk: AppExtensionSDK;
 }
@@ -31,6 +43,7 @@ interface ConfigState {
   isButtonLoading?: boolean;
   validationMessage?: string;
   parameters: AppInstallationParameters;
+  contentTypes: ContentType[];
 }
 
 export default class Config extends Component<ConfigProps, ConfigState> {
@@ -40,6 +53,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       isButtonLoading: false,
       validationMessage: '',
       parameters: {},
+      contentTypes: [],
     };
 
     // `onConfigure` allows to configure a callback to be

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -183,7 +183,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
             controls: [],
           };
 
-          compatibleFields.map(({ fieldId, enabled }: CompatibleField) => {
+          compatibleFields.forEach(({ fieldId, enabled }: CompatibleField) => {
             if (enabled) {
               editorInterface[contentId].controls.push({ fieldId });
             }

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -386,10 +386,10 @@ export default class Config extends Component<ConfigProps, ConfigState> {
               <br></br>
               {this.state.contentTypes.map(
                 (
-                  { contentName, compatibleFields }: ContentType,
+                  { contentName, contentId, compatibleFields }: ContentType,
                   contentIndex,
                 ) => (
-                  <div>
+                  <div key={contentId}>
                     <Subheading>{contentName}</Subheading>
                     <br></br>
                     <Form>
@@ -399,6 +399,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                           fieldIndex,
                         ) => (
                           <CheckboxField
+                            key={contentId + '-' + fieldId}
                             labelText={fieldName}
                             id={fieldId}
                             helpText={`FieldId: ${fieldId}`}

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -68,7 +68,11 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     const parameters: AppInstallationParameters | null =
       await this.props.sdk.app.getParameters();
 
-    this.setState(parameters ? { parameters } : this.state, () => {
+    // Forcing the type here to include any[] as Promise.all can return `undefined`
+    // but we will filter all values out before returning the final array
+    const contentTypes: (ContentType | any)[] =
+      await this.getContentTypesWithCompatibleFields();
+
       // Once preparation has finished, call `setReady` to hide
       // the loading screen and present the app to a user.
       this.props.sdk.app.setReady();


### PR DESCRIPTION
The intention of this feat is to query the Contentful `spaces` API in order to construct an array of content types with compatible fields (ie `Object`) that users can elect to add the imgix app to. From this, we can surface an interface that allows users to select these fields within the Configuration page.

Once the user has selected any number of fields to install the app to, we then to construct an object in the shape expected by `onConfigure` to persist these choices. For any content type, if there is at least one `enabled` entry then we will create an array of `fieldId` corresponding to the `enabled` (or selected) fields. Once this is returned as `targetState` within `onConfigure`, then the imgix app will be installed in the selected fields.


See demo of this in action:

https://user-images.githubusercontent.com/15919091/134733477-c1566c58-a060-4326-9d27-bd1063dce169.mov


