### PR TITLE
fix: add `autoComplete` attribute to API key field

### DIFF
--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -343,6 +343,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                   validationMessage={this.state.validationMessage}
                   textInputProps={{
                     type: 'password',
+                    autoComplete: 'new-api-key',
                   }}
                   onChange={this.handleChange}
                 />


### PR DESCRIPTION
Addresses the following browser warning `[DOM] Input elements should have autocomplete attributes (suggested: "new-password")`