### PR TITLE
feat: add ability for user to search for assets by `categories`, `keywords`, or `origin_path`

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -148,6 +148,14 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     leading: true,
   });
 
+  searchOnClick = () => {
+    const { searchTerm } = this.state;
+    const searchQuery = `?filter[or:categories]=${searchTerm}&filter[or:keywords]=${searchTerm}&filter[or:origin_path]=${searchTerm}&page[number]=${this.state.page.currentIndex}&page[size]=18`;
+    searchTerm ? this.requestImageUrls(searchQuery) : this.requestImageUrls();
+  };
+
+  debounceSearchOnClick = debounce(this.searchOnClick, 1000, { leading: true });
+
   setSelectedSource = (source: SourceProps) => {
     this.setState({ selectedSource: source });
   };
@@ -292,7 +300,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
               ) => this.setState({ searchTerm: e.target.value })}
             />
-            <Button buttonType="muted" icon="Search">
+            <Button
+              buttonType="muted"
+              icon="Search"
+              onClick={this.debounceSearchOnClick}
+            >
               Search
             </Button>
           </div>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component, ChangeEvent } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
 import { debounce } from 'lodash';
@@ -29,6 +29,7 @@ interface DialogState {
   selectedSource: Partial<SourceProps>;
   page: PageProps;
   verified: boolean; // if API key is verified
+  searchTerm?: string;
   assets: Array<string>;
   errors: IxError[]; // array of IxErrors if any
 }
@@ -285,6 +286,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             <TextInput
               type="search"
               placeholder="Search by name or folder path"
+              value={this.state.searchTerm || ''}
+              onChange={(
+                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+              ) => this.setState({ searchTerm: e.target.value })}
             />
             <Button buttonType="muted" icon="Search">
               Search

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -71,6 +71,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         totalPageCount: 1,
       },
       verified,
+      searchTerm: '',
       assets: [],
       errors: [],
     };
@@ -295,7 +296,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             <TextInput
               type="search"
               placeholder="Search by name or folder path"
-              value={this.state.searchTerm || ''}
+              value={this.state.searchTerm}
               onChange={(
                 e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
               ) => this.setState({ searchTerm: e.target.value })}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../helpers/errors';
 
 import './Dialog.css';
-import { TextInput, Button } from '@contentful/forma-36-react-components';
+import { TextInput, Button, Form } from '@contentful/forma-36-react-components';
 
 interface DialogProps {
   sdk: DialogExtensionSDK;
@@ -293,21 +293,24 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         />
         {this.state.selectedSource.id && (
           <div>
-            <TextInput
-              type="search"
-              placeholder="Search by name or folder path"
-              value={this.state.searchTerm}
-              onChange={(
-                e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-              ) => this.setState({ searchTerm: e.target.value })}
-            />
-            <Button
-              buttonType="muted"
-              icon="Search"
-              onClick={this.debounceSearchOnClick}
-            >
-              Search
-            </Button>
+            <Form>
+              <TextInput
+                type="search"
+                placeholder="Search by name or folder path"
+                value={this.state.searchTerm}
+                onChange={(
+                  e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+                ) => this.setState({ searchTerm: e.target.value })}
+              />
+              <Button
+                buttonType="muted"
+                icon="Search"
+                type="submit"
+                onClick={this.debounceSearchOnClick}
+              >
+                Search
+              </Button>
+            </Form>
           </div>
         )}
         <ImageGallery

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -175,9 +175,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     }
   }
 
-  getImages = async () => {
+  getImages = async (query: string) => {
     const assets = await this.state.imgix.request(
-      `assets/${this.state.selectedSource?.id}?page[number]=${this.state.page.currentIndex}&page[size]=18`,
+      `assets/${this.state.selectedSource?.id}${query}`,
     );
     // TODO: add more explicit types for image
     this.handleTotalImageCount(
@@ -186,12 +186,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     return assets;
   };
 
-  getImagePaths = async () => {
+  getImagePaths = async (query: string) => {
     let images,
       allOriginPaths: string[] = [];
 
     try {
-      images = await this.getImages();
+      images = await this.getImages(query);
     } catch (error) {
       // APIError will emit more helpful data for debugging
       if (error instanceof APIError) {
@@ -241,10 +241,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
    * Requests and constructs fully-qualified image URLs, saving the results to
    * state
    */
-  requestImageUrls = async () => {
+  requestImageUrls = async (query?: string) => {
     // if selected source, return images
     if (Object.keys(this.state.selectedSource).length) {
-      const images = await this.getImagePaths();
+      const defaultQuery = `?page[number]=${this.state.page.currentIndex}&page[size]=18`;
+      const images = await this.getImagePaths(query || defaultQuery);
       const assets = this.constructUrl(images);
       // if at least one path, remove placeholders
 

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -15,6 +15,7 @@ interface GalleryProps {
   getTotalImageCount: (totalImageCount: number) => void;
   pageInfo: PageProps;
   changePage: (newPageIndex: number) => void;
+  assets: Array<string>;
 }
 
 interface GalleryState {
@@ -32,100 +33,6 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     };
   }
 
-  getImages = async () => {
-    const assets = await this.props.imgix.request(
-      `assets/${this.props.selectedSource?.id}?page[number]=${this.props.pageInfo.currentIndex}&page[size]=18`,
-    );
-    // TODO: add more explicit types for image
-    this.props.getTotalImageCount(
-      parseInt((assets.meta.cursor as any).totalRecords || 0),
-    );
-    return assets;
-  };
-
-  getImagePaths = async () => {
-    let images,
-      allOriginPaths: string[] = [];
-
-    try {
-      images = await this.getImages();
-    } catch (error) {
-      // APIError will emit more helpful data for debugging
-      if (error instanceof APIError) {
-        console.error(error.toString());
-      } else {
-        console.error(error);
-      }
-      return allOriginPaths;
-    }
-
-    /*
-     * Resolved requests can either return an array of objects or a single
-     * object via the `data` top-level field. When parsing all enabled sources,
-     * both possibilities must be accounted for.
-     */
-    if (images) {
-      const imagesArray = Array.isArray(images.data)
-        ? images.data
-        : [images.data];
-      imagesArray.map((image: any) =>
-        // TODO: add more explicit types for image
-        allOriginPaths.push(image.attributes.origin_path),
-      );
-
-      return allOriginPaths;
-    } else {
-      return [];
-    }
-  };
-
-  /*
-   * Constructs an array of imgix image URL from the selected source in the
-   * application Dialog component
-   */
-  constructUrl(images: string[]) {
-    const scheme = 'https://';
-    const domain = this.props.selectedSource.name;
-    const imgixDomain = '.imgix.net';
-
-    const urls = images.map(
-      (path: string) => scheme + domain + imgixDomain + path,
-    );
-    return urls;
-  }
-
-  /*
-   * Requests and constructs fully-qualified image URLs, saving the results to
-   * state
-   */
-  async requestImageUrls() {
-    // if selected source, return images
-    if (Object.keys(this.props.selectedSource).length) {
-      const images = await this.getImagePaths();
-      const fullUrls = this.constructUrl(images);
-      // if at least one path, remove placeholders
-
-      if (fullUrls.length) {
-        this.setState({ fullUrls });
-      } else {
-        this.setState({ fullUrls: [] });
-      }
-    }
-  }
-
-  async componentDidMount() {
-    this.requestImageUrls();
-  }
-
-  async componentDidUpdate(prevProps: GalleryProps) {
-    if (
-      this.props.selectedSource.id !== prevProps.selectedSource.id ||
-      this.props.pageInfo.currentIndex !== prevProps.pageInfo.currentIndex
-    ) {
-      this.requestImageUrls();
-    }
-  }
-
   handleClick = (selectedImage: string) => this.setState({ selectedImage });
 
   handleSubmit = () => {
@@ -135,14 +42,14 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
   render() {
     const { fullUrls, selectedImage } = this.state;
 
-    if (!fullUrls.length) {
+    if (!this.props.assets.length) {
       return <ImagePlaceholder />;
     }
 
     return (
       <div>
         <div className="ix-gallery">
-          {fullUrls.map((url: string) => {
+          {this.props.assets.map((url: string) => {
             return (
               <GridImage
                 key={url}
@@ -160,7 +67,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
             changePage={this.props.changePage}
           />
           <ImageSelectButton
-            hidden={!!fullUrls.length}
+            hidden={!!this.props.assets.length}
             disabled={selectedImage === ''}
             handleSubmit={this.handleSubmit}
           />


### PR DESCRIPTION
This PR adds the UI & logic to enable users to be able to search across assets in their selected Source.

In order to implement search, we need the search UI (text input and button) to have access to the same methods where assets are requested and parsed. Unfortunately, there did not appear to be a very react-idiomatic way to handle this situation while also keeping the Dialog and ImageGallery components fully separated.

The proposed solution here is to pull up all asset-related logic to the Dialog level. Once all processing is done, the final asset data (fully-qualified image URLs) can be passed down to ImageGallery as a prop to be rendered.

The search features extends this idea by refactoring the chain of methods used to request and parse assets to accept a query that is ultimately concatenated to the imgix management API call. This way, a particular call for `assets` can retrieve a filtered response, while others can retrieve all images.

https://user-images.githubusercontent.com/15919091/139183970-62357397-0158-4ee2-be0a-4d06f1512fe7.mov

It's worth noting that there is a small step remaining to clean up some of the artifacts left behind from the refactor. But for the sake of keeping this PR as succinct as possible, I will address that tail end of work in a separate PR.

