### PR TITLE
fix: reset currentPageIndex when executing search query

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -277,7 +277,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       if (assets.length) {
         this.setState({
           assets,
-          isSearching: this.state.isSearching && false,
+          isSearching: false,
         });
       } else {
         this.setState({ assets: [] });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -151,8 +151,21 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   searchOnClick = () => {
     const { searchTerm } = this.state;
-    const searchQuery = `?filter[or:categories]=${searchTerm}&filter[or:keywords]=${searchTerm}&filter[or:origin_path]=${searchTerm}&page[number]=${this.state.page.currentIndex}&page[size]=18`;
-    searchTerm ? this.requestImageUrls(searchQuery) : this.requestImageUrls();
+
+    this.setState(
+      {
+        page: {
+          ...this.state.page,
+          currentIndex: 0,
+        },
+      },
+      () => {
+        const searchQuery = `?filter[or:categories]=${searchTerm}&filter[or:keywords]=${searchTerm}&filter[or:origin_path]=${searchTerm}&page[number]=${this.state.page.currentIndex}&page[size]=18`;
+        searchTerm
+          ? this.requestImageUrls(searchQuery)
+          : this.requestImageUrls();
+      },
+    );
   };
 
   debounceSearchOnClick = debounce(this.searchOnClick, 1000, { leading: true });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -32,6 +32,7 @@ interface DialogState {
   searchTerm?: string;
   assets: Array<string>;
   errors: IxError[]; // array of IxErrors if any
+  isSearching: boolean;
 }
 
 export type PageProps = {
@@ -74,6 +75,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       searchTerm: '',
       assets: [],
       errors: [],
+      isSearching: false,
     };
   }
 
@@ -158,6 +160,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           ...this.state.page,
           currentIndex: 0,
         },
+        isSearching: true,
       },
       () => {
         const searchQuery = `?filter[or:categories]=${searchTerm}&filter[or:keywords]=${searchTerm}&filter[or:origin_path]=${searchTerm}&page[number]=${this.state.page.currentIndex}&page[size]=18`;
@@ -272,7 +275,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       // if at least one path, remove placeholders
 
       if (assets.length) {
-        this.setState({ assets });
+        this.setState({
+          assets,
+          isSearching: this.state.isSearching && false,
+        });
       } else {
         this.setState({ assets: [] });
       }
@@ -282,7 +288,8 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   async componentDidUpdate(prevProps: DialogProps, prevState: DialogState) {
     if (
       this.state.selectedSource.id !== prevState.selectedSource.id ||
-      this.state.page.currentIndex !== prevState.page.currentIndex
+      (this.state.page.currentIndex !== prevState.page.currentIndex &&
+        !this.state.isSearching)
     ) {
       this.requestImageUrls();
     }


### PR DESCRIPTION
Because we cannot guarantee that a specific search will return N or more pages, we will reset the current page to the first index (0). This way, if a user is currently viewing page 2, the app will not attempt to show them page 2 of their search when one does not exist.

**General Note about this PR:**
The `Dialog` component will watch for one of two state changes and rerender if either occurs: if a new Source is selected or if a new page of Assets is requested. Because we reset the `currentPageIndex` when executing a search request, this will trigger an extra request for assets in parallel with the search request. Aside from the fact that it's a superfluous request, it will also trigger a ratelimit error from the imgix API.

Although not ideal, the speediest workaround here is to track if a search is conducted through a variable in state, `isSearching`. Based on if this flag is true, we can tell the component not to rerender. This is not an elegant solution because the `componentDidUpdate` lifecycle listens for changes that will trigger new assets to get requested, but has no visibility if a page change is caused via the pagination UI or the search function. In the future, we should rework the logic here so that we don't need to rely so much on state changes to make the correct request.


https://user-images.githubusercontent.com/15919091/141214740-c6cd7a5c-b9de-4a8d-890a-8ec7077bef13.mov

