### PR TITLE
feat: add error type for empty search results

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -272,12 +272,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     // if selected source, return images
     if (Object.keys(this.state.selectedSource).length) {
       const defaultQuery = `?page[number]=${this.state.page.currentIndex}&page[size]=18`;
-      let images;
-      if (query) {
-        images = await this.getImagePaths(query, noSearchImagesError());
-      } else {
-        images = await this.getImagePaths(defaultQuery, noOriginImagesError());
-      }
+
+      const images = query
+        ? await this.getImagePaths(query, noSearchImagesError())
+        : await this.getImagePaths(defaultQuery, noOriginImagesError());
 
       if (images.length > 0 && this.state.errors.length > 0) {
         this.resetNErrors(this.state.errors.length);

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -279,6 +279,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         images = await this.getImagePaths(defaultQuery, noOriginImagesError());
       }
 
+      if (images.length > 0 && this.state.errors.length > 0) {
+        this.resetNErrors(this.state.errors.length);
+      }
+
       const assets = this.constructUrl(images);
       // if at least one path, remove placeholders
 

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -38,7 +38,7 @@ const ERROR_MESSAGES = {
     type: 'warning',
   },
   noSearchImagesError: {
-    message: `Consider trying to search by something else.`,
+    message: `Consider trying to search for something else.`,
     name: 'No results found',
     type: 'warning',
   }

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -2,7 +2,8 @@ export type NoteType = 'primary' | 'positive' | 'negative' | 'warning';
 export type ErrorType =
   | `InvalidApiKeyError`
   | `NoSourcesError`
-  | `NoOriginImagesError`;
+  | `NoOriginImagesError`
+  | `noSearchImagesError`;
 
 const DASHBOARD_URL = 'https://dashboard.imgix.com';
 
@@ -36,6 +37,11 @@ const ERROR_MESSAGES = {
     name: 'This Source has no Origin images',
     type: 'warning',
   },
+  noSearchImagesError: {
+    message: `Consider trying to search by something else.`,
+    name: 'No results found',
+    type: 'warning',
+  }
 } as const;
 
 type ErrorMessageType = keyof typeof ERROR_MESSAGES;
@@ -46,7 +52,7 @@ type ErrorMessageType = keyof typeof ERROR_MESSAGES;
  * This class is used to manage imgix API error messages and warnings. It
  * extends the builtin `Error` class and adds the `type` property.
  *
- * @param {NoteType} type "`InvalidApiKeyError` | `NoSourcesError` | `NoOriginImagesError`"
+ * @param {NoteType} type "`InvalidApiKeyError` | `NoSourcesError` | `NoOriginImagesError` | `noSearchImagesError`"
  * @param {string} message The error message string.
  *
  * @example
@@ -78,3 +84,6 @@ export const noSourcesError = (message?: string) =>
 
 export const noOriginImagesError = (message?: string) =>
   new IxError('NoOriginImagesError', message);
+
+export const noSearchImagesError = (message?: string) =>
+  new IxError('noSearchImagesError', message);


### PR DESCRIPTION
This PR displays a specific error Note when a search returns empty results. Part of this implementation requires passing the an error type through the function chain that parses image paths to determine which error to display, either a `noSearchImagesError` or a `noOriginImagesError`.

https://user-images.githubusercontent.com/15919091/141515011-23bbd7ad-71c3-41d4-8c85-1a886e2277cd.mov