### PR TITLE
feat: stringify JSON fields within attributes field 

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,5 +185,141 @@ query MyQuery {
 `;
 ```
 
+### Metadata
+
+Users may also access metadata associated with an image via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/image-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
+
+```graphql
+query MyQuery {
+  allContentfulArticle {
+    nodes {
+      bannerImage {
+        src
+        attributes {
+          analyzed_content_warnings
+          analyzed_faces
+          analyzed_tags
+          color_model
+          color_profile
+          content_type
+          custom_fields
+          date_created
+          date_modified
+          dpi_height
+          dpi_width
+          face_count
+          file_size
+          has_frames
+          media_height
+          media_kind
+          media_width
+          origin_path
+          source_id
+          tags
+          uploaded_by_api
+          warning_adult
+          warning_medical
+          warning_racy
+          warning_spoof
+          warning_violence
+        }
+      }
+    }
+  }
+}
+```
+
+returns something similar to:
+
+```json
+{
+  "data": {
+    "allContentfulArticle": {
+      "nodes": [
+        {
+          "bannerImage": {
+            "src": "https://fourbottle.imgix.net/heroes/woman-stirring.jpg",
+            "attributes": {
+              "analyzed_content_warnings": true,
+              "analyzed_faces": true,
+              "analyzed_tags": true,
+              "color_model": "RGB",
+              "color_profile": "c2",
+              "content_type": "image/jpeg",
+              "custom_fields": "\"\"",
+              "date_created": 1625796011,
+              "date_modified": 1642786873,
+              "dpi_height": 72,
+              "dpi_width": 72,
+              "face_count": 1,
+              "file_size": 3411741,
+              "has_frames": false,
+              "media_height": 4000,
+              "media_kind": "IMAGE",
+              "media_width": 6000,
+              "origin_path": "/heroes/woman-stirring.jpg",
+              "source_id": "5f73d9798d5327eb5194d54a",
+              "tags": "{\"Arm\":0.9448454976081848,\"Cup\":0.8950006365776062,\"Drinkware\":0.9177042841911316,\"Glasses\":0.9809675216674805,\"Hand\":0.9596579074859619,\"Joint\":0.9762823581695557,\"Photograph\":0.94278883934021,\"Shoulder\":0.9465579986572266,\"Tableware\":0.949840784072876,\"Vision care\":0.9289617538452148}",
+              "uploaded_by_api": false,
+              "warning_adult": 1,
+              "warning_medical": 1,
+              "warning_racy": 2,
+              "warning_spoof": 1,
+              "warning_violence": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
+
+```js
+{data.allContentfulArticle.edges.map(({ node }) => (
+  <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+    <ImgixGatsbyImage
+      src={node.bannerImage.src}
+      imgixParams={{
+        auto: "format,compress",
+        crop: "faces,edges",
+      }}
+      layout="constrained"
+      width={350}
+      aspectRatio={16 / 9}
+      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+      alt="An imgix-served image from Contentful"
+    />
+    {node.bannerImage.attributes.custom_fields ?
+     Object.entries(JSON.parse(node.bannerImage.attributes.custom_fields)).map(([key, value]) => (<p>{key}: {value}</p>)) : <br></br>}
+    {Object.entries(JSON.parse(node.bannerImage.attributes.colors.dominant_colors)).map(([key, value]) => (<p>{key}: {value}</p>))}
+    {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(([key, value]) => (<p>{key}: {value}</p>))}
+  </div>
+))}
+
+export const query = graphql`
+{
+  allContentfulArticle {
+    edges {
+      node {
+        bannerImage {
+          src
+          attributes {
+            custom_fields
+            colors {
+              dominant_colors
+            }
+            tags
+          }
+        }
+      }
+    }
+  }
+}
+`;
+```
+
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fcontentful.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fcontentful?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- ix-docs-ignore -->
+
 ![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
 A Contentful app that integrates with imgix's [Image Manager](https://docs.imgix.com/setup/image-manager). Browse, search, and insert image assets into your content quickly and easily. Simplify your content editing workflow within Contentful and empower your developers with imgix’s powerful image rendering and optimization service.
@@ -52,7 +53,9 @@ Upon installation, configure the app using an API key generated via the imgix [D
 Following the instructions on the screen, enter in the API key and press `Verify`. If the key is valid, you will receive a notification that the key has been successfully verified. If verification fails, you will need to ensure that the key was entered correctly.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-b078-068ddaaa0c86.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-b078-068ddaaa0c86.mp4">
@@ -63,7 +66,9 @@ https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-
 The configuration page surfaces the option for users to select pre-existing content fields that are compatible with the imgix app. Note that the app is configured to integrate with `JSON object` fields only, therefore only fields of this type will be displayed. Users may prefer this method over selecting individual fields manually for each applicable content model.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056243-487233b5-228a-4f7b-bcd3-a99bed55f460.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056243-487233b5-228a-4f7b-bcd3-a99bed55f460.mp4">
@@ -75,7 +80,9 @@ Of the many content types that users can choose from, imgix specifically integra
 Designate a field to use imgix on by navigating to that field’s Appearance tab and selecting the app. This step can be skipped if you already [assigned the app](#assign-to-fields-optional) directly to the desired field(s).
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-93aa-0bea3b975d1b.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-93aa-0bea3b975d1b.mp4">
@@ -86,7 +93,9 @@ https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-
 From any instance of a field using the imgix app, a modal can be opened to browse images by imgix source. First, select a desired source to browse images from. Using any of the pagination buttons, navigate each page of assets to choose from. After selecting an image, it can be inserted to the field via the `Add image` button. Additionally, there are options to replace an image, or clear a selection from the field altogether.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-970a-2921fab44e8d.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-970a-2921fab44e8d.mp4">
@@ -97,7 +106,9 @@ https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-
 The imgix app enables users to conduct a keyword search across assets in a source. Using the search box near the top of the modal will execute a search across multiple pre-determined fields: file origin path, image tags, and categories. To learn more about these fields, see our Image Manager [documentation](https://docs.imgix.com/setup/image-manager#image-details).
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov">
@@ -149,39 +160,37 @@ returns something similar to:
 Developers can leverage the power of imgix's [rendering API](https://docs.imgix.com/apis/rendering) downstream from where the image was selected in Contentful. We recommend piping the value of the `src` field of the image through to one of imgix's [SDKs](https://docs.imgix.com/libraries#frontend-libraries). The example below builds on the previous one by passing the image `src` through to [@imgix/gatsby](https://github.com/imgix/gatsby) component:
 
 ```js
-import React from "react";
-import { graphql } from "gatsby";
-import { ImgixGatsbyImage } from "@imgix/gatsby";
+import React from 'react';
+import { graphql } from 'gatsby';
+import { ImgixGatsbyImage } from '@imgix/gatsby';
 
 export default function Page({ data }) {
-  return (
-    data.allContentfulArticle.nodes.map(({ node }) => (
-        <ImgixGatsbyImage
-          src={node.avatar.src}
-          imgixParams={{
-            auto: "format,compress",
-            crop: "faces,edges",
-          }}
-          layout="constrained"
-          width={350}
-          aspectRatio={16 / 9}
-          sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
-          alt="An imgix-served image from Contentful"
-        />
-    ))
-  );
+  return data.allContentfulArticle.nodes.map(({ node }) => (
+    <ImgixGatsbyImage
+      src={node.avatar.src}
+      imgixParams={{
+        auto: 'format,compress',
+        crop: 'faces,edges',
+      }}
+      layout="constrained"
+      width={350}
+      aspectRatio={16 / 9}
+      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+      alt="An imgix-served image from Contentful"
+    />
+  ));
 }
 
 export const query = graphql`
-query MyQuery {
-  allContentfulArticle {
-    nodes {
-      avatar {
-        src
+  query MyQuery {
+    allContentfulArticle {
+      nodes {
+        avatar {
+          src
+        }
       }
     }
   }
-}
 `;
 ```
 
@@ -278,48 +287,72 @@ returns something similar to:
 **Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
-{data.allContentfulArticle.edges.map(({ node }) => (
-  <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
-    <ImgixGatsbyImage
-      src={node.bannerImage.src}
-      imgixParams={{
-        auto: "format,compress",
-        crop: "faces,edges",
-      }}
-      layout="constrained"
-      width={350}
-      aspectRatio={16 / 9}
-      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
-      alt="An imgix-served image from Contentful"
-    />
-    {node.bannerImage.attributes.custom_fields ?
-     Object.entries(JSON.parse(node.bannerImage.attributes.custom_fields)).map(([key, value]) => (<p>{key}: {value}</p>)) : <br></br>}
-    {Object.entries(JSON.parse(node.bannerImage.attributes.colors.dominant_colors)).map(([key, value]) => (<p>{key}: {value}</p>))}
-    {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(([key, value]) => (<p>{key}: {value}</p>))}
-  </div>
-))}
+{
+  data.allContentfulArticle.edges.map(({ node }) => (
+    <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+      <ImgixGatsbyImage
+        src={node.bannerImage.src}
+        imgixParams={{
+          auto: 'format,compress',
+          crop: 'faces,edges',
+        }}
+        layout="constrained"
+        width={350}
+        aspectRatio={16 / 9}
+        sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+        alt="An imgix-served image from Contentful"
+      />
+      {node.bannerImage.attributes.custom_fields ? (
+        Object.entries(
+          JSON.parse(node.bannerImage.attributes.custom_fields),
+        ).map(([key, value]) => (
+          <p>
+            {key}: {value}
+          </p>
+        ))
+      ) : (
+        <br></br>
+      )}
+      {Object.entries(
+        JSON.parse(node.bannerImage.attributes.colors.dominant_colors),
+      ).map(([key, value]) => (
+        <p>
+          {key}: {value}
+        </p>
+      ))}
+      {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(
+        ([key, value]) => (
+          <p>
+            {key}: {value}
+          </p>
+        ),
+      )}
+    </div>
+  ));
+}
 
 export const query = graphql`
-{
-  allContentfulArticle {
-    edges {
-      node {
-        bannerImage {
-          src
-          attributes {
-            custom_fields
-            colors {
-              dominant_colors
+  {
+    allContentfulArticle {
+      edges {
+        node {
+          bannerImage {
+            src
+            attributes {
+              custom_fields
+              colors {
+                dominant_colors
+              }
+              tags
             }
-            tags
           }
         }
       }
     }
   }
-}
 `;
 ```
 
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fcontentful.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fcontentful?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ returns something similar to:
 **Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields (`custom_fields`, `tags`, `colors.dominant_colors`) will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
-{
-  data.allContentfulArticle.edges.map(({ node }) => (
+export default function Page({ data }) {
+  return data.allContentfulArticle.edges.map(({ node }) => (
     <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
       <ImgixGatsbyImage
         src={node.bannerImage.src}

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ returns something similar to:
 }
 ```
 
-**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
+**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields (`custom_fields`, `tags`, `colors.dominant_colors`) will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
 {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -258,9 +258,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   * Stringifies all JSON field values within the asset.attribute object
   */
   stringifyJsonFields = (asset: AssetProps) => {
-    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields);
-    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors);
-    asset.attributes.tags = JSON.stringify(asset.attributes.tags);
+    const replaceNullWithEmptyString = (_: any, value: any) => (value === null) ? "" : value;
+    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields, replaceNullWithEmptyString);
+    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors, replaceNullWithEmptyString);
+    asset.attributes.tags = JSON.stringify(asset.attributes.tags, replaceNullWithEmptyString);
   };
 
   /*

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -243,10 +243,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       const assetsArray = Array.isArray(assets.data)
         ? assets.data
         : [assets.data];
-      assetObjects = assetsArray.map((asset: any) =>
+      assetObjects = assetsArray.map((asset: any) => {
+        this.stringifyJsonFields(asset);
         // TODO: add more explicit types for `asset`
-        ({ src: asset.attributes.origin_path, attributes: asset.attributes }),
-      );
+        return ({ src: asset.attributes.origin_path, attributes: asset.attributes });
+      });
 
       return assetObjects;
     } else {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -255,6 +255,15 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   };
 
   /*
+  * Stringifies all JSON field values within the asset.attribute object
+  */
+  stringifyJsonFields = (asset: AssetProps) => {
+    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields);
+    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors);
+    asset.attributes.tags = JSON.stringify(asset.attributes.tags);
+  };
+
+  /*
    * Constructs an array of imgix image URL from the selected source in the
    * application Dialog component
    */


### PR DESCRIPTION
## Description
Because the keys of nested JSON fields (e.g. `tags`, `custom_fields`, `colors`) can vary from one object to the next, this can cause brittleness for users who are interfacing with the Contentful API using GraphQL. This is because GraphQL requires users to be explicit about what fields they want to return, rather than being able to query an object for all fields regardless of what they are.

To help with this, some users have suggested [[1](gatsbyjs/gatsby#2490)][[2](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3)] stringifying nested JSON fields and then parsing it clientside. This better ensures that queries won't break even if the returning data's underlying shape somehow breaks. Now each of the following fields will be returned as a string:

- tags
- custom_fields
- colors.dominant_colors

## Current Behavior (before this PR)

GraphQL will allow the user to specify a the value(s) of a JSON field such as `custom_fields`. In this case, the returning node has a key value `{"coffee": "latte"}`. However, once that image is removed from Contentful's side, the same query will error out, as such node with that custom field value will no longer exist.

<img width="916" alt="Screen Shot 2022-01-04 at 6 18 55 PM" src="https://user-images.githubusercontent.com/15919091/151466441-ff5d53db-4aef-416a-a7f5-130c4110513c.png">
<img width="916" alt="Screen Shot 2022-01-04 at 6 19 13 PM" src="https://user-images.githubusercontent.com/15919091/151466470-f643abb3-2a74-4e81-9579-60637b46d590.png">

<img width="837" alt="Screen Shot 2022-01-04 at 6 45 23 PM" src="https://user-images.githubusercontent.com/15919091/151466510-83e22156-1c5c-40ba-9207-b06ad6795412.png">


## Testing

After this change,  we see that the aforementioned fields are now returned as strings:

<img width="1351" alt="Screen Shot 2022-01-21 at 5 02 30 PM" src="https://user-images.githubusercontent.com/15919091/150606070-8e1352ce-0dd2-4427-b23b-24cadcf313c9.png">

This means users will need to take the extra step of parsing these strings back into objects, example shown below (shortened for clarity):
```js
{data.allContentfulArticle.edges.map(({ node }) => (
  <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
    <ImgixGatsbyImage
      src={node.bannerImage.src}
      imgixParams={{
        auto: "format,compress",
        crop: "faces,edges",
      }}
      layout="constrained"
      width={350}
      aspectRatio={16 / 9}
      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
      alt="An imgix-served image from Contentful"
    />
    <br></br>
    {node.bannerImage.attributes.custom_fields ?
     Object.entries(JSON.parse(node.bannerImage.attributes.custom_fields)).map(([key, value]) => (<p>{key}: {value}</p>)) : <br></br>}
    <br></br>
    {Object.entries(JSON.parse(node.bannerImage.attributes.colors.dominant_colors)).map(([key, value]) => (<p>{key}: {value}</p>))}
    <br></br>
    {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(([key, value]) => (<p>{key}: {value}</p>))}
  </div>
))}

export const query = graphql`
{
  allContentfulArticle {
    edges {
      node {
        bannerImage {
          src
          attributes {
            custom_fields
            colors {
              dominant_colors
            }
            tags
          }
        }
      }
    }
  }
}
`;
```

Which results in the following:
<img width="887" alt="Screen Shot 2022-01-21 at 5 06 15 PM" src="https://user-images.githubusercontent.com/15919091/150606456-ff90ebdd-32f4-4f49-a01b-c89fd64d8bc2.png">

