### PR TITLE
feat: add asset metadata to final returned object

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,5 +185,141 @@ query MyQuery {
 `;
 ```
 
+### Metadata
+
+Users may also access metadata associated with an image via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/image-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
+
+```graphql
+query MyQuery {
+  allContentfulArticle {
+    nodes {
+      bannerImage {
+        src
+        attributes {
+          analyzed_content_warnings
+          analyzed_faces
+          analyzed_tags
+          color_model
+          color_profile
+          content_type
+          custom_fields
+          date_created
+          date_modified
+          dpi_height
+          dpi_width
+          face_count
+          file_size
+          has_frames
+          media_height
+          media_kind
+          media_width
+          origin_path
+          source_id
+          tags
+          uploaded_by_api
+          warning_adult
+          warning_medical
+          warning_racy
+          warning_spoof
+          warning_violence
+        }
+      }
+    }
+  }
+}
+```
+
+returns something similar to:
+
+```json
+{
+  "data": {
+    "allContentfulArticle": {
+      "nodes": [
+        {
+          "bannerImage": {
+            "src": "https://fourbottle.imgix.net/heroes/woman-stirring.jpg",
+            "attributes": {
+              "analyzed_content_warnings": true,
+              "analyzed_faces": true,
+              "analyzed_tags": true,
+              "color_model": "RGB",
+              "color_profile": "c2",
+              "content_type": "image/jpeg",
+              "custom_fields": "\"\"",
+              "date_created": 1625796011,
+              "date_modified": 1642786873,
+              "dpi_height": 72,
+              "dpi_width": 72,
+              "face_count": 1,
+              "file_size": 3411741,
+              "has_frames": false,
+              "media_height": 4000,
+              "media_kind": "IMAGE",
+              "media_width": 6000,
+              "origin_path": "/heroes/woman-stirring.jpg",
+              "source_id": "5f73d9798d5327eb5194d54a",
+              "tags": "{\"Arm\":0.9448454976081848,\"Cup\":0.8950006365776062,\"Drinkware\":0.9177042841911316,\"Glasses\":0.9809675216674805,\"Hand\":0.9596579074859619,\"Joint\":0.9762823581695557,\"Photograph\":0.94278883934021,\"Shoulder\":0.9465579986572266,\"Tableware\":0.949840784072876,\"Vision care\":0.9289617538452148}",
+              "uploaded_by_api": false,
+              "warning_adult": 1,
+              "warning_medical": 1,
+              "warning_racy": 2,
+              "warning_spoof": 1,
+              "warning_violence": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
+
+```js
+{data.allContentfulArticle.edges.map(({ node }) => (
+  <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+    <ImgixGatsbyImage
+      src={node.bannerImage.src}
+      imgixParams={{
+        auto: "format,compress",
+        crop: "faces,edges",
+      }}
+      layout="constrained"
+      width={350}
+      aspectRatio={16 / 9}
+      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+      alt="An imgix-served image from Contentful"
+    />
+    {node.bannerImage.attributes.custom_fields ?
+     Object.entries(JSON.parse(node.bannerImage.attributes.custom_fields)).map(([key, value]) => (<p>{key}: {value}</p>)) : <br></br>}
+    {Object.entries(JSON.parse(node.bannerImage.attributes.colors.dominant_colors)).map(([key, value]) => (<p>{key}: {value}</p>))}
+    {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(([key, value]) => (<p>{key}: {value}</p>))}
+  </div>
+))}
+
+export const query = graphql`
+{
+  allContentfulArticle {
+    edges {
+      node {
+        bannerImage {
+          src
+          attributes {
+            custom_fields
+            colors {
+              dominant_colors
+            }
+            tags
+          }
+        }
+      }
+    }
+  }
+}
+`;
+```
+
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fcontentful.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fcontentful?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- ix-docs-ignore -->
+
 ![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
 A Contentful app that integrates with imgix's [Image Manager](https://docs.imgix.com/setup/image-manager). Browse, search, and insert image assets into your content quickly and easily. Simplify your content editing workflow within Contentful and empower your developers with imgix’s powerful image rendering and optimization service.
@@ -52,7 +53,9 @@ Upon installation, configure the app using an API key generated via the imgix [D
 Following the instructions on the screen, enter in the API key and press `Verify`. If the key is valid, you will receive a notification that the key has been successfully verified. If verification fails, you will need to ensure that the key was entered correctly.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-b078-068ddaaa0c86.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-b078-068ddaaa0c86.mp4">
@@ -63,7 +66,9 @@ https://user-images.githubusercontent.com/15919091/137049820-8ffc4bfd-43f1-41d2-
 The configuration page surfaces the option for users to select pre-existing content fields that are compatible with the imgix app. Note that the app is configured to integrate with `JSON object` fields only, therefore only fields of this type will be displayed. Users may prefer this method over selecting individual fields manually for each applicable content model.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056243-487233b5-228a-4f7b-bcd3-a99bed55f460.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056243-487233b5-228a-4f7b-bcd3-a99bed55f460.mp4">
@@ -75,7 +80,9 @@ Of the many content types that users can choose from, imgix specifically integra
 Designate a field to use imgix on by navigating to that field’s Appearance tab and selecting the app. This step can be skipped if you already [assigned the app](#assign-to-fields-optional) directly to the desired field(s).
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-93aa-0bea3b975d1b.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-93aa-0bea3b975d1b.mp4">
@@ -86,7 +93,9 @@ https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-
 From any instance of a field using the imgix app, a modal can be opened to browse images by imgix source. First, select a desired source to browse images from. Using any of the pagination buttons, navigate each page of assets to choose from. After selecting an image, it can be inserted to the field via the `Add image` button. Additionally, there are options to replace an image, or clear a selection from the field altogether.
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-970a-2921fab44e8d.mp4
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-970a-2921fab44e8d.mp4">
@@ -97,7 +106,9 @@ https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-
 The imgix app enables users to conduct a keyword search across assets in a source. Using the search box near the top of the modal will execute a search across multiple pre-determined fields: file origin path, image tags, and categories. To learn more about these fields, see our Image Manager [documentation](https://docs.imgix.com/setup/image-manager#image-details).
 
 <!-- ix-docs-ignore -->
+
 https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov
+
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov">
@@ -149,39 +160,37 @@ returns something similar to:
 Developers can leverage the power of imgix's [rendering API](https://docs.imgix.com/apis/rendering) downstream from where the image was selected in Contentful. We recommend piping the value of the `src` field of the image through to one of imgix's [SDKs](https://docs.imgix.com/libraries#frontend-libraries). The example below builds on the previous one by passing the image `src` through to [@imgix/gatsby](https://github.com/imgix/gatsby) component:
 
 ```js
-import React from "react";
-import { graphql } from "gatsby";
-import { ImgixGatsbyImage } from "@imgix/gatsby";
+import React from 'react';
+import { graphql } from 'gatsby';
+import { ImgixGatsbyImage } from '@imgix/gatsby';
 
 export default function Page({ data }) {
-  return (
-    data.allContentfulArticle.nodes.map(({ node }) => (
-        <ImgixGatsbyImage
-          src={node.avatar.src}
-          imgixParams={{
-            auto: "format,compress",
-            crop: "faces,edges",
-          }}
-          layout="constrained"
-          width={350}
-          aspectRatio={16 / 9}
-          sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
-          alt="An imgix-served image from Contentful"
-        />
-    ))
-  );
+  return data.allContentfulArticle.nodes.map(({ node }) => (
+    <ImgixGatsbyImage
+      src={node.avatar.src}
+      imgixParams={{
+        auto: 'format,compress',
+        crop: 'faces,edges',
+      }}
+      layout="constrained"
+      width={350}
+      aspectRatio={16 / 9}
+      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+      alt="An imgix-served image from Contentful"
+    />
+  ));
 }
 
 export const query = graphql`
-query MyQuery {
-  allContentfulArticle {
-    nodes {
-      avatar {
-        src
+  query MyQuery {
+    allContentfulArticle {
+      nodes {
+        avatar {
+          src
+        }
       }
     }
   }
-}
 `;
 ```
 
@@ -278,48 +287,72 @@ returns something similar to:
 **Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
-{data.allContentfulArticle.edges.map(({ node }) => (
-  <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
-    <ImgixGatsbyImage
-      src={node.bannerImage.src}
-      imgixParams={{
-        auto: "format,compress",
-        crop: "faces,edges",
-      }}
-      layout="constrained"
-      width={350}
-      aspectRatio={16 / 9}
-      sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
-      alt="An imgix-served image from Contentful"
-    />
-    {node.bannerImage.attributes.custom_fields ?
-     Object.entries(JSON.parse(node.bannerImage.attributes.custom_fields)).map(([key, value]) => (<p>{key}: {value}</p>)) : <br></br>}
-    {Object.entries(JSON.parse(node.bannerImage.attributes.colors.dominant_colors)).map(([key, value]) => (<p>{key}: {value}</p>))}
-    {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(([key, value]) => (<p>{key}: {value}</p>))}
-  </div>
-))}
+{
+  data.allContentfulArticle.edges.map(({ node }) => (
+    <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
+      <ImgixGatsbyImage
+        src={node.bannerImage.src}
+        imgixParams={{
+          auto: 'format,compress',
+          crop: 'faces,edges',
+        }}
+        layout="constrained"
+        width={350}
+        aspectRatio={16 / 9}
+        sizes="(min-width: 1024px) calc(30vw - 128px), (min-width: 768px) calc(50vw - 100px), calc(100vw - 70px)"
+        alt="An imgix-served image from Contentful"
+      />
+      {node.bannerImage.attributes.custom_fields ? (
+        Object.entries(
+          JSON.parse(node.bannerImage.attributes.custom_fields),
+        ).map(([key, value]) => (
+          <p>
+            {key}: {value}
+          </p>
+        ))
+      ) : (
+        <br></br>
+      )}
+      {Object.entries(
+        JSON.parse(node.bannerImage.attributes.colors.dominant_colors),
+      ).map(([key, value]) => (
+        <p>
+          {key}: {value}
+        </p>
+      ))}
+      {Object.entries(JSON.parse(node.bannerImage.attributes.tags)).map(
+        ([key, value]) => (
+          <p>
+            {key}: {value}
+          </p>
+        ),
+      )}
+    </div>
+  ));
+}
 
 export const query = graphql`
-{
-  allContentfulArticle {
-    edges {
-      node {
-        bannerImage {
-          src
-          attributes {
-            custom_fields
-            colors {
-              dominant_colors
+  {
+    allContentfulArticle {
+      edges {
+        node {
+          bannerImage {
+            src
+            attributes {
+              custom_fields
+              colors {
+                dominant_colors
+              }
+              tags
             }
-            tags
           }
         }
       }
     }
   }
-}
 `;
 ```
 
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fcontentful.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fcontentful?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ returns something similar to:
 **Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields (`custom_fields`, `tags`, `colors.dominant_colors`) will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
-{
-  data.allContentfulArticle.edges.map(({ node }) => (
+export default function Page({ data }) {
+  return data.allContentfulArticle.edges.map(({ node }) => (
     <div className="p-4 lg:w-1/3 md:w-1/2 sm:w-full">
       <ImgixGatsbyImage
         src={node.bannerImage.src}

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ returns something similar to:
 }
 ```
 
-**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
+**Note**: Certain fields under `attributes` are returned as strings to provide better [resiliency](https://forums.fauna.com/t/how-to-store-arbitrary-json-object-via-graphql/142/3) when used with GraphQL. Therefore, these fields (`custom_fields`, `tags`, `colors.dominant_colors`) will need to be parsed back into JSON objects after being queried. The example below demonstrates how to do this:
 
 ```js
 {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -23,6 +23,11 @@ interface DialogProps {
   sdk: DialogExtensionSDK;
 }
 
+export interface AssetProps {
+  src: string;
+  attributes: Record<string, any>;
+}
+
 interface DialogState {
   imgix: ImgixAPI;
   isOpen: boolean;
@@ -31,7 +36,7 @@ interface DialogState {
   page: PageProps;
   verified: boolean; // if API key is verified
   searchTerm?: string;
-  assets: Array<string>;
+  assets: AssetProps[];
   errors: IxError[]; // array of IxErrors if any
   isSearching: boolean;
 }
@@ -215,7 +220,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   getImagePaths = async (query: string, error: IxError) => {
     let images,
-      allOriginPaths: string[] = [];
+      allAssets: AssetProps[] = [];
 
     try {
       images = await this.getImages(query, error);
@@ -226,7 +231,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       } else {
         console.error(error);
       }
-      return allOriginPaths;
+      return allAssets;
     }
 
     /*
@@ -238,12 +243,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       const imagesArray = Array.isArray(images.data)
         ? images.data
         : [images.data];
-      imagesArray.map((image: any) =>
+      allAssets = imagesArray.map((image: any) =>
         // TODO: add more explicit types for image
         allOriginPaths.push(image.attributes.origin_path),
       );
 
-      return allOriginPaths;
+      return allAssets;
     } else {
       return [];
     }
@@ -253,7 +258,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
    * Constructs an array of imgix image URL from the selected source in the
    * application Dialog component
    */
-  constructUrl(images: string[]) {
+  buildAssetWithFullUrl(images: AssetProps[]) {
     const scheme = 'https://';
     const domain = this.state.selectedSource.name;
     const imgixDomain = '.imgix.net';
@@ -281,7 +286,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         this.resetNErrors(this.state.errors.length);
       }
 
-      const assets = this.constructUrl(images);
+      const assets = this.buildAssetWithFullUrl(images);
       // if at least one path, remove placeholders
 
       if (assets.length) {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -258,9 +258,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   * Stringifies all JSON field values within the asset.attribute object
   */
   stringifyJsonFields = (asset: AssetProps) => {
-    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields);
-    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors);
-    asset.attributes.tags = JSON.stringify(asset.attributes.tags);
+    const replaceNullWithEmptyString = (_: any, value: any) => (value === null) ? "" : value;
+    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields, replaceNullWithEmptyString);
+    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors, replaceNullWithEmptyString);
+    asset.attributes.tags = JSON.stringify(asset.attributes.tags, replaceNullWithEmptyString);
   };
 
   /*

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -245,7 +245,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         : [images.data];
       allAssets = imagesArray.map((image: any) =>
         // TODO: add more explicit types for image
-        allOriginPaths.push(image.attributes.origin_path),
+        ({ src: image.attributes.origin_path, attributes: image.attributes }),
       );
 
       return allAssets;
@@ -263,10 +263,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     const domain = this.state.selectedSource.name;
     const imgixDomain = '.imgix.net';
 
-    const urls = images.map(
-      (path: string) => scheme + domain + imgixDomain + path,
-    );
-    return urls;
+    const transformedAsset = images.map((asset) => ({
+      ...asset,
+      src: scheme + domain + imgixDomain + asset.src,
+    }));
+    return transformedAsset;
   }
 
   /*

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -243,10 +243,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       const assetsArray = Array.isArray(assets.data)
         ? assets.data
         : [assets.data];
-      assetObjects = assetsArray.map((asset: any) =>
+      assetObjects = assetsArray.map((asset: any) => {
+        this.stringifyJsonFields(asset);
         // TODO: add more explicit types for `asset`
-        ({ src: asset.attributes.origin_path, attributes: asset.attributes }),
-      );
+        return ({ src: asset.attributes.origin_path, attributes: asset.attributes });
+      });
 
       return assetObjects;
     } else {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -255,6 +255,15 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   };
 
   /*
+  * Stringifies all JSON field values within the asset.attribute object
+  */
+  stringifyJsonFields = (asset: AssetProps) => {
+    asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields);
+    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors);
+    asset.attributes.tags = JSON.stringify(asset.attributes.tags);
+  };
+
+  /*
    * Constructs an array of imgix image URL from the selected source in the
    * application Dialog component
    */

--- a/src/components/Dialog/index.ts
+++ b/src/components/Dialog/index.ts
@@ -1,7 +1,8 @@
-import Dialog, { SourceProps as _SourceProps, PageProps as _PageProps } from './Dialog';
+import Dialog, { SourceProps as _SourceProps, PageProps as _PageProps, AssetProps as _AssetProps } from './Dialog';
 import { DialogHeader as _DialogHeader } from './DialogHeader';
 
 export default Dialog;
 export const DialogHeader = _DialogHeader;
 export type SourceProps = _SourceProps;
 export type PageProps = _PageProps;
+export type AssetProps = _AssetProps;

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -3,13 +3,14 @@ import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { debounce } from 'lodash';
 
 import { FieldImagePreview, FieldPrompt } from './';
+import { AssetProps } from '../Dialog';
 
 interface FieldProps {
   sdk: FieldExtensionSDK;
 }
 
 interface FieldState {
-  imagePath: string | undefined;
+  selectedAsset: AssetProps | undefined;
 }
 
 export default class Field extends Component<FieldProps, FieldState> {
@@ -19,7 +20,7 @@ export default class Field extends Component<FieldProps, FieldState> {
     const storedValue = this.props.sdk.field.getValue();
 
     this.state = {
-      imagePath: storedValue?.src || '',
+      selectedAsset: storedValue || undefined,
     };
   }
 
@@ -32,29 +33,29 @@ export default class Field extends Component<FieldProps, FieldState> {
         shouldCloseOnOverlayClick: true,
         allowHeightOverflow: true,
         parameters: {
-          selectedImage: this.state.imagePath,
+          selectedImage: this.state.selectedAsset,
         },
       })
-      .then((imagePath) =>
-        this.setState({ imagePath }, () =>
-          this.props.sdk.field.setValue({ src: imagePath }),
+      .then((selectedAsset) =>
+        this.setState({ selectedAsset }, () =>
+          this.props.sdk.field.setValue(selectedAsset),
         ),
       );
   };
   debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });
 
   clearSelection = () => {
-    this.setState({ imagePath: undefined }, () =>
+    this.setState({ selectedAsset: undefined }, () =>
       this.props.sdk.field.setValue(undefined),
     );
   };
 
   render() {
     const updateHeightHandler = this.props.sdk.window.updateHeight;
-    if (this.state.imagePath) {
+    if (this.state.selectedAsset) {
       return (
         <FieldImagePreview
-          imagePath={this.state.imagePath}
+          imagePath={this.state.selectedAsset?.src}
           openDialog={this.debounceOpenDialog}
           updateHeight={updateHeightHandler}
           clearSelection={this.clearSelection}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 
-import { SourceProps, PageProps } from '../Dialog';
+import { SourceProps, PageProps, AssetProps } from '../Dialog';
 import { ImageSelectButton } from '../ImageSelect/ImageSelect';
 import { GridImage, ImagePlaceholder, ImagePagination } from './';
 
@@ -12,11 +12,11 @@ interface GalleryProps {
   sdk: DialogExtensionSDK;
   pageInfo: PageProps;
   changePage: (newPageIndex: number) => void;
-  assets: Array<string>;
+  assets: AssetProps[];
 }
 
 interface GalleryState {
-  selectedImage: string;
+  selectedAsset: AssetProps | undefined;
 }
 
 export class Gallery extends Component<GalleryProps, GalleryState> {
@@ -24,18 +24,18 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     super(props);
 
     this.state = {
-      selectedImage: '',
+      selectedAsset: undefined,
     };
   }
 
-  handleClick = (selectedImage: string) => this.setState({ selectedImage });
+  handleClick = (selectedAsset: AssetProps) => this.setState({ selectedAsset });
 
   handleSubmit = () => {
-    this.props.sdk.close(this.state.selectedImage);
+    this.props.sdk.close(this.state.selectedAsset);
   };
 
   render() {
-    const { selectedImage } = this.state;
+    const { selectedAsset } = this.state;
 
     if (!this.props.assets.length) {
       return <ImagePlaceholder />;
@@ -44,13 +44,13 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     return (
       <div>
         <div className="ix-gallery">
-          {this.props.assets.map((url: string) => {
+          {this.props.assets.map((asset) => {
             return (
               <GridImage
-                key={url}
-                selected={selectedImage === url}
-                imageSrc={url}
-                handleClick={() => this.handleClick(url)}
+                key={asset.src}
+                selected={selectedAsset?.src === asset.src}
+                imageSrc={asset.src}
+                handleClick={() => this.handleClick(asset)}
               />
             );
           })}
@@ -63,7 +63,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
           />
           <ImageSelectButton
             hidden={!!this.props.assets.length}
-            disabled={selectedImage === ''}
+            disabled={selectedAsset?.src === ''}
             handleSubmit={this.handleSubmit}
           />
         </div>


### PR DESCRIPTION
Includes all logic and documentation for exposing asset metadata on returned JSON objects via the imgix app.

Related to #105, #106, #107 