### PR TITLE
fix: do not access `dominant_colors` if parent object `colors` is undefined

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -261,8 +261,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   stringifyJsonFields = (asset: AssetProps) => {
     const replaceNullWithEmptyString = (_: any, value: any) => (value === null) ? "" : value;
     asset.attributes.custom_fields = JSON.stringify(asset.attributes.custom_fields, replaceNullWithEmptyString);
-    asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors.dominant_colors, replaceNullWithEmptyString);
     asset.attributes.tags = JSON.stringify(asset.attributes.tags, replaceNullWithEmptyString);
+    if (asset.attributes.colors?.dominant_colors) {
+      asset.attributes.colors.dominant_colors = JSON.stringify(asset.attributes.colors?.dominant_colors, replaceNullWithEmptyString);
+    }
   };
 
   /*


### PR DESCRIPTION
This PR adds extra guardrails when attempting to access the nested object `dominant_colors`. Optional chaining is added so that in the off chance that `colors` is undefined, the app will still display images in the Gallery.

Fixes #111 

<img width="393" alt="Screen Shot 2022-02-01 at 2 42 38 PM" src="https://user-images.githubusercontent.com/15919091/152039551-18250893-73c1-402c-8ad5-3869d0129a1a.png">