### PR TITLE
config: add `pluginOrigin` field to every ImgixAPI instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react-dom": "^17.0.0",
         "contentful-ui-extensions-sdk": "^3.31.0",
         "cross-env": "^7.0.3",
-        "imgix-management-js": "^1.2.1",
+        "imgix-management-js": "^1.3.0-rc.1",
         "lodash.debounce": "^4.0.8",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -9867,9 +9867,9 @@
       }
     },
     "node_modules/imgix-management-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/imgix-management-js/-/imgix-management-js-1.2.2.tgz",
-      "integrity": "sha512-sdLvAetwThc6p/fxX+7snuPsW9AXwTOAHJ4DWFtG5lxxDxYlymv97oBu0PqvAFTnRBBbWZnPrGz/aYDyUFZPTg==",
+      "version": "1.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/imgix-management-js/-/imgix-management-js-1.3.0-rc.1.tgz",
+      "integrity": "sha512-GCmfXQS5mFT5Mn2VNl5HtACOtAGK0y9KfAvBh8P2bbi7wIL+o2hjr1pChH4SKVxu1mahyFcr5cfjgBB2ku0Vrw==",
       "dependencies": {
         "node-fetch": "^2.6.0"
       }
@@ -28154,9 +28154,9 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "imgix-management-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/imgix-management-js/-/imgix-management-js-1.2.2.tgz",
-      "integrity": "sha512-sdLvAetwThc6p/fxX+7snuPsW9AXwTOAHJ4DWFtG5lxxDxYlymv97oBu0PqvAFTnRBBbWZnPrGz/aYDyUFZPTg==",
+      "version": "1.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/imgix-management-js/-/imgix-management-js-1.3.0-rc.1.tgz",
+      "integrity": "sha512-GCmfXQS5mFT5Mn2VNl5HtACOtAGK0y9KfAvBh8P2bbi7wIL+o2hjr1pChH4SKVxu1mahyFcr5cfjgBB2ku0Vrw==",
       "requires": {
         "node-fetch": "^2.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/react-dom": "^17.0.0",
     "contentful-ui-extensions-sdk": "^3.31.0",
     "cross-env": "^7.0.3",
-    "imgix-management-js": "^1.2.1",
+    "imgix-management-js": "^1.3.0-rc.1",
     "lodash.debounce": "^4.0.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -210,6 +210,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
 
     const imgix = new ImgixAPI({
       apiKey: this.state.parameters.imgixAPIKey || '',
+      pluginOrigin: "imgix-contentful/1.2.1",
     });
 
     let updatedInstallationParameters: AppInstallationParameters = {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -66,6 +66,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     const verified = !!installationParameters.successfullyVerified;
     const imgix = new ImgixAPI({
       apiKey,
+      pluginOrigin: "imgix-contentful/1.2.1",
     });
 
     this.state = {


### PR DESCRIPTION
Experimenting with the new `pluginOrigin` configuration on imgix-management-js