### PR TITLE
feat: disable upload for webfolder source

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -64,6 +64,7 @@ export type PageProps = {
 export type SourceProps = {
   id: string;
   name: string;
+  type: 'azure' | 'gcs' | 's3' | 'webfolder' | 'webproxy';
   domain: string;
 };
 
@@ -140,9 +141,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         if (source.attributes.enabled) {
           const id = source.id;
           const name = source.attributes.name;
+          const type = source.attributes.deployment.type;
           // there may be multiple domains, but we'll extract the first one for now
           let domain = source.attributes.deployment.imgix_subdomains[0];
-          result.push({ id, name, domain });
+          result.push({ id, name, type, domain });
         }
         return result;
       },

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -503,7 +503,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                   Search
                 </Button>
               </Form>
-              <UploadButton handleFileChange={this.openFileForm} />
+              <UploadButton
+                disabled={selectedSource && selectedSource.type === 'webfolder'}
+                handleFileChange={this.openFileForm}
+              />
             </div>
           )}
         </div>

--- a/src/components/UploadButton/UploadButton.tsx
+++ b/src/components/UploadButton/UploadButton.tsx
@@ -9,6 +9,7 @@ export function UploadButton(props: {
     previewSource: string,
     isUploading: boolean,
   ) => void;
+  disabled?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const handleClick = () => {
@@ -42,6 +43,7 @@ export function UploadButton(props: {
         className="ix-uploadButton"
         icon="Download"
         type="submit"
+        disabled={props.disabled}
         onClick={handleClick}
       >
         Upload


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
This PR adds `this.source.attribute.deployment.type` to each source stored in state. It uses this to disable/enable the button for the `selectedSource` when rendering.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
# Before
Upload was not disabled for `webfolder` sources.

<!-- After this PR... -->
# After
Upload disabled for `webfolder` sources.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## 🖼️  Screenshots


https://user-images.githubusercontent.com/16711614/199096135-7e6d1a05-75ef-4bb2-becb-51c54471093d.mov

## Steps to test
1. Pull down, run start, open contenful staging
2. Select a webfolder source from the dropdown
3. Try to upload

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [ ] Add new passing unit tests to cover the code introduced by your PR (if applicable).
