### PR TITLE
fix: dropdown indexing

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -107,7 +107,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
   getSources = async () => {
     return await this.state.imgix.request(
-      'sources?sort=name&page[number]=1&page[size]=100',
+      'sources?sort=name&page[number]=0&page[size]=200',
     );
   };
 


### PR DESCRIPTION
# Before
The extended drop-down for sources indexes from 1 instead of 0.  As a result, it displays  the second hundred sources.
# After
The extended drop-down for sources indexes from 0, displaying alphabetical sources prior to the second hundred. The source limit has been increased to 200.