### PR TITLE
feat: disable upload button after click

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -128,6 +128,24 @@
   border: none;
 }
 
+.ix-input-readonly > input {
+  background-color: #fff;
+  border-color: #aec1cc;
+  box-shadow: 0 1px 0 rgb(246 247 247 / 32%);
+  color: #111b2b42;
+}
+
+.ix-input-readonly > *:focus {
+  outline: none;
+  border-color: #aec1cc;
+  box-shadow: 0 1px 0 rgb(246 247 247 / 32%);
+  color: #111b2b42;
+}
+
+.ix-input-readonly > *:hover {
+  cursor: not-allowed;
+}
+
 .ix-upload-preview > img {
   display: block;
   margin: 0 auto;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -609,6 +609,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                   className="ix-upload-confirm-button"
                   onClick={this.uploadAssets}
                   loading={this.state.isUploading}
+                  disabled={this.state.isUploading}
                 >
                   {this.state.isUploading ? 'Uploading' : 'Confirm Upload'}
                 </Button>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -584,6 +584,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                     <div className="ix-upload-destination">
                       <p>destination path</p>
                       <TextInput
+                        className={
+                          this.state.isUploading ? 'ix-input-readonly' : ''
+                        }
                         value={this.state.uploadForm.destination || '/'}
                         onChange={this.updateDestinationFilePath}
                         placeholder="/"
@@ -601,6 +604,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                   />
                   <div className="ix-upload-preview-filename">
                     <TextInput
+                      className={
+                        this.state.isUploading ? 'ix-input-readonly' : ''
+                      }
                       value={this.state.uploadForm.filename || ''}
                       onChange={this.updateFileName}
                       isReadOnly={this.state.isUploading}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -561,6 +561,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                   buttonType="naked"
                   icon="Close"
                   className="ix-close-button"
+                  disabled={this.state.isUploading}
                   onClick={() => this.setShowUpload(false)}
                 ></Button>
               </div>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -577,6 +577,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                       resetErrors={() =>
                         this.resetNErrors(this.state.errors.length)
                       }
+                      disabled={this.state.isUploading}
                     />
                   </div>
                   <form onSubmit={this.uploadAssets}>
@@ -586,6 +587,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                         value={this.state.uploadForm.destination || '/'}
                         onChange={this.updateDestinationFilePath}
                         placeholder="/"
+                        isReadOnly={this.state.isUploading}
                       ></TextInput>
                     </div>
                   </form>
@@ -601,6 +603,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                     <TextInput
                       value={this.state.uploadForm.filename || ''}
                       onChange={this.updateFileName}
+                      isReadOnly={this.state.isUploading}
                     ></TextInput>
                   </div>
                 </div>

--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -16,6 +16,7 @@ interface Props {
   allSources: Array<any>;
   setSource: Function;
   resetErrors: Function;
+  disabled?: boolean;
 }
 
 export function SourceSelectDropdown({
@@ -24,6 +25,7 @@ export function SourceSelectDropdown({
   allSources,
   setSource,
   resetErrors,
+  disabled,
 }: Props): ReactElement {
   const [isOpen, setOpen] = React.useState(false);
   const handleClick = (source: SourceProps) => {
@@ -44,6 +46,7 @@ export function SourceSelectDropdown({
           className="ix-dropdown"
           indicateDropdown
           onClick={() => setOpen(!isOpen)}
+          disabled={disabled}
         >
           {selectedSource.name || 'Select an imgix Source'}
         </Button>


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->
## Description
This PR disables the upload button after it's clicked. It's disabled as long as `isUploading` in state is `true`. This impedes users from clicking the button many times and trying to upload the same asset over and over.

It also disables the cancel button, source-select dropdown, path field, and filename field while `isUploading` is `true`.
<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
Users could click upload over and over.
<!-- After this PR... -->
## After
The button is disabled after its clicked.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## 🖼️ Screenshots


https://user-images.githubusercontent.com/16711614/201010293-8f900da1-186d-4076-96b9-de68351bd1f5.mov






## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] All existing unit tests are still passing (if applicable).
