### PR TITLE
chore: update asset errors

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -12,8 +12,9 @@ import { ChangeEvent, Component } from 'react';
 import {
   invalidApiKeyError,
   IxError,
-  noOriginImagesError,
-  noSearchImagesError,
+  noOriginAssetsError,
+  noOriginAssetsWebFolderError,
+  noSearchAssetsError,
   noSourcesError,
 } from '../../helpers/errors';
 import { AppInstallationParameters } from '../ConfigScreen/';
@@ -338,8 +339,13 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       const defaultQuery = `?page[number]=${this.state.page.currentIndex}&page[size]=18`;
 
       const assetObjects = query
-        ? await this.getAssetObjects(query, noSearchImagesError())
-        : await this.getAssetObjects(defaultQuery, noOriginImagesError());
+        ? await this.getAssetObjects(query, noSearchAssetsError())
+        : this.state.selectedSource.type === 'webfolder'
+        ? await this.getAssetObjects(
+            defaultQuery,
+            noOriginAssetsWebFolderError(),
+          )
+        : await this.getAssetObjects(defaultQuery, noOriginAssetsError());
 
       if (assetObjects.length > 0 && this.state.errors.length > 0) {
         this.resetNErrors(this.state.errors.length);
@@ -553,6 +559,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             error={this.state.errors[0]}
             type={this.state.errors[0].type}
             resetErrorBoundary={this.resetNErrors}
+            dismissable={this.state.errors[0].dismissable}
           />
         )}
         {this.state.showUpload && (

--- a/src/components/Gallery/EmptySourcePlaceholder.tsx
+++ b/src/components/Gallery/EmptySourcePlaceholder.tsx
@@ -1,0 +1,14 @@
+import { ReactElement } from 'react';
+import { Paragraph } from '@contentful/forma-36-react-components';
+
+import './ImagePlaceholder.css';
+
+export function EmptySourcePlaceholder(): ReactElement {
+  return (
+    <div className="ix-grid-item-placeholder">
+      <Paragraph className="ix-placeholder-text">
+        Add assets to this Source by selecting Upload.
+      </Paragraph>
+    </div>
+  );
+}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -2,7 +2,12 @@ import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { Component } from 'react';
 
 import { AssetProps, PageProps, SourceProps } from '../Dialog';
-import { GridImage, ImagePlaceholder } from './';
+import {
+  GridImage,
+  WebFolderPlaceholder,
+  SourcePlaceholder,
+  EmptySourcePlaceholder,
+} from './';
 
 import { ActionBar } from '../ActionBar';
 import './ImageGallery.css';
@@ -37,7 +42,13 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
   render() {
     const { selectedAsset } = this.state;
     if (!this.props.assets.length) {
-      return <ImagePlaceholder />;
+      return !this.props.selectedSource.type ? (
+        <SourcePlaceholder /> //No source selected
+      ) : this.props.selectedSource.type === 'webfolder' ? (
+        <WebFolderPlaceholder /> //Empty webfolder selected
+      ) : (
+        <EmptySourcePlaceholder /> //Empty source selected
+      );
     }
 
     return (

--- a/src/components/Gallery/SourcePlaceholder.tsx
+++ b/src/components/Gallery/SourcePlaceholder.tsx
@@ -3,7 +3,7 @@ import { Paragraph } from '@contentful/forma-36-react-components';
 
 import './ImagePlaceholder.css';
 
-export function ImagePlaceholder(): ReactElement {
+export function SourcePlaceholder(): ReactElement {
   return (
     <div className="ix-grid-item-placeholder">
       <Paragraph className="ix-placeholder-text">

--- a/src/components/Gallery/WebFolderPlaceholder.tsx
+++ b/src/components/Gallery/WebFolderPlaceholder.tsx
@@ -1,0 +1,14 @@
+import { ReactElement } from 'react';
+import { Paragraph } from '@contentful/forma-36-react-components';
+
+import './ImagePlaceholder.css';
+
+export function WebFolderPlaceholder(): ReactElement {
+  return (
+    <div className="ix-grid-item-placeholder">
+      <Paragraph className="ix-placeholder-text">
+        Select a different Source to view your visual media.
+      </Paragraph>
+    </div>
+  );
+}

--- a/src/components/Gallery/index.ts
+++ b/src/components/Gallery/index.ts
@@ -1,9 +1,13 @@
 import { Gallery as _ImageGallery } from './ImageGallery';
 import { GridImage as _GridImage } from './GridImage';
-import { ImagePlaceholder as _ImagePlaceholder } from './ImagePlaceholder';
+import { SourcePlaceholder as _SourcePlaceholder } from './SourcePlaceholder';
+import { EmptySourcePlaceholder as _EmptySourcePlaceholder } from './EmptySourcePlaceholder';
+import { WebFolderPlaceholder as _WebFolderPlaceholder } from './WebFolderPlaceholder';
 import { ImagePagination as _ImagePagination } from './ImagePagination';
 
 export const ImageGallery = _ImageGallery;
 export const GridImage = _GridImage;
-export const ImagePlaceholder = _ImagePlaceholder;
+export const EmptySourcePlaceholder = _EmptySourcePlaceholder;
+export const SourcePlaceholder = _SourcePlaceholder;
+export const WebFolderPlaceholder = _WebFolderPlaceholder;
 export const ImagePagination = _ImagePagination;

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -7,12 +7,14 @@ export interface INoteProps {
   type: 'primary' | 'positive' | 'negative' | 'warning';
   error: Error;
   resetErrorBoundary: () => void;
+  dismissable: boolean;
 }
 
 export function IxNote({
   error,
   type,
   resetErrorBoundary,
+  dismissable,
 }: INoteProps): ReactElement {
   const [message, _link, ...rest] = error.message.split('$');
   const [link, title] = _link?.split('|') || ['', ''];
@@ -23,7 +25,7 @@ export function IxNote({
       <Note
         noteType={type}
         title={error.name}
-        hasCloseButton
+        hasCloseButton={dismissable}
         onClose={resetErrorBoundary}
       >
         {message + ' '}

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -16,9 +16,11 @@ export function IxNote({
   resetErrorBoundary,
   dismissable,
 }: INoteProps): ReactElement {
-  const [message, _link, ...rest] = error.message.split('$');
+  const [message, _link, mid, _secondLink, ...rest] = error.message.split('$');
   const [link, title] = _link?.split('|') || ['', ''];
   const linkTitle = title?.length ? title : link;
+  const [secondLink, secondTitle] = _secondLink?.split('|') || ['', ''];
+  const secondLinkTitle = secondTitle?.length ? secondTitle : secondLink;
 
   return (
     <div className="ix-note">
@@ -31,6 +33,10 @@ export function IxNote({
         {message + ' '}
         <TextLink target="window" href={link}>
           {linkTitle}
+        </TextLink>
+        {mid}
+        <TextLink target="window" href={secondLink}>
+          {secondLinkTitle}
         </TextLink>
         {' ' + rest}
       </Note>

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -2,10 +2,13 @@ export type NoteType = 'primary' | 'positive' | 'negative' | 'warning';
 export type ErrorType =
   | `InvalidApiKeyError`
   | `NoSourcesError`
-  | `NoOriginImagesError`
-  | `noSearchImagesError`;
+  | `NoOriginAssetsError`
+  | `NoOriginAssetsWebFolderError`
+  | `noSearchAssetsError`;
 
 const DASHBOARD_URL = 'https://dashboard.imgix.com';
+const WEBFOLDER_DOCUMENTATION_URL = `https://docs.imgix.com/setup/serving-assets#web-folder`;
+const SUPPORT_URL = `https://imgix.com/contact`;
 
 /*
 * The error messages are split on `$` and then again on `|`. The `$` is used to
@@ -26,21 +29,31 @@ const ERROR_MESSAGES = {
     contact your system administrator.`,
     name: 'Invalid API Key',
     type: 'negative',
+    dismissable: false,
   },
   NoSourcesError: {
     message: `Go to $${DASHBOARD_URL + '/sources'}$ to add an imgix Source.`,
     name: 'You have no imgix Sources',
     type: 'warning',
+    dismissable: false,
   },
-  NoOriginImagesError: {
-    message: `Go to $${DASHBOARD_URL + '/sources'}$ to add Origin images to this Source.`,
-    name: 'This Source has no Origin images',
+  NoOriginAssetsError: {
+    message: `To upload images to this Source, select the Upload button located in the top-right-hand corner of the modal.`,
+    name: 'This Source has no Origin assets',
     type: 'warning',
+    dismissable: false,
+  },
+  NoOriginAssetsWebFolderError: {
+    message: `imgix couldn’t find any Origin Assets in this Web Folder. Please check back later, visit our $${WEBFOLDER_DOCUMENTATION_URL}|documentation,$ or $${SUPPORT_URL}| contact Support$.`,
+    name: 'This Web Folder Source has no Origin Assets',
+    type: 'warning',
+    dismissable: false,
   },
   noSearchImagesError: {
     message: `Consider trying to search for something else.`,
     name: 'No results found',
     type: 'warning',
+    dismissable: true,
   }
 } as const;
 
@@ -52,7 +65,7 @@ type ErrorMessageType = keyof typeof ERROR_MESSAGES;
  * This class is used to manage imgix API error messages and warnings. It
  * extends the builtin `Error` class and adds the `type` property.
  *
- * @param {NoteType} type "`InvalidApiKeyError` | `NoSourcesError` | `NoOriginImagesError` | `noSearchImagesError`"
+ * @param {NoteType} type "`InvalidApiKeyError` | `NoSourcesError` | `NoOriginAssetsError` | `NoOriginAssetsWebFolderError` | `noSearchAssetsError`"
  * @param {string} message The error message string.
  *
  * @example
@@ -67,12 +80,15 @@ type ErrorMessageType = keyof typeof ERROR_MESSAGES;
 
 export class IxError extends Error {
   type: NoteType;
+  dismissable: boolean;
   constructor(type: ErrorType, message?: string) {
     super(message);
     this.name =
       ERROR_MESSAGES[type as ErrorMessageType].name || 'imgix API Error';
     this.message = message || ERROR_MESSAGES[type as ErrorMessageType].message;
     this.type = ERROR_MESSAGES[type as ErrorMessageType].type || 'warning';
+    this.dismissable = ERROR_MESSAGES[type as ErrorMessageType].dismissable;
+    
   }
 }
 
@@ -82,8 +98,11 @@ export const invalidApiKeyError = (message?: string) =>
 export const noSourcesError = (message?: string) =>
   new IxError('NoSourcesError', message);
 
-export const noOriginImagesError = (message?: string) =>
-  new IxError('NoOriginImagesError', message);
+export const noOriginAssetsError = (message?: string) =>
+  new IxError('NoOriginAssetsError', message);
 
-export const noSearchImagesError = (message?: string) =>
-  new IxError('noSearchImagesError', message);
+export const noOriginAssetsWebFolderError = (message?: string) =>
+  new IxError('NoOriginAssetsWebFolderError', message);
+
+export const noSearchAssetsError = (message?: string) =>
+  new IxError('noSearchAssetsError', message);

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -44,7 +44,7 @@ const ERROR_MESSAGES = {
     dismissable: false,
   },
   NoOriginAssetsWebFolderError: {
-    message: `imgix couldn’t find any Origin Assets in this Web Folder. Please check back later, visit our $${WEBFOLDER_DOCUMENTATION_URL}|documentation,$ or $${SUPPORT_URL}| contact Support$.`,
+    message: `imgix couldn’t find any Origin Assets in this Web Folder. Please check back later, visit our $${WEBFOLDER_DOCUMENTATION_URL}|documentation,$ or $${SUPPORT_URL}| contact Support.$`,
     name: 'This Web Folder Source has no Origin Assets',
     type: 'warning',
     dismissable: false,


### PR DESCRIPTION
- Adds new error for webfolders with no assets
- Replaces image errors with asset errors to reflect change from Image Manager to Asset Manager
- Errors not resolvable through Contentful are no longer dismissable
- Updates fallback gallery text to reflect source type and situation

# Screenshots
### Before
Standard source
<img width="1100" alt="Screen Shot 2022-11-16 at 1 04 28 AM" src="https://user-images.githubusercontent.com/8823474/202099004-443c5e6e-637a-4716-96de-c2b857ba35bd.png">

Web folder
<img width="1106" alt="Screen Shot 2022-11-16 at 1 04 45 AM" src="https://user-images.githubusercontent.com/8823474/202099013-d8431b43-ae39-46e6-a0b1-40df8115c39c.png">


### After
Standard source
<img width="770" alt="Screen Shot 2022-11-16 at 1 00 46 AM" src="https://user-images.githubusercontent.com/8823474/202099031-36882a74-c9c7-480a-a1ca-0cf22a12218e.png">

Web folder
<img width="774" alt="Screen Shot 2022-11-16 at 1 01 12 AM" src="https://user-images.githubusercontent.com/8823474/202099067-2a796b5c-4f3a-4a5b-bbb7-33e3e5e68a06.png">
