### PR TITLE
chore: filters out webproxy sources

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -143,7 +143,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     enabledSources = sourcesArray.reduce(
       (result: SourceProps[], source: any) => {
         // TODO: add more explicit types for source
-        if (source.attributes.enabled) {
+        if (
+          source.attributes.enabled &&
+          // filters out unsupported webproxy sources
+          source.attributes.deployment.type !== 'webproxy'
+        ) {
           const id = source.id;
           const name = source.attributes.name;
           const type = source.attributes.deployment.type;


### PR DESCRIPTION
# Before
Webproxy sources were selectable through the source dropdown.

# After
Webproxy sources are no longer visible through the source dropdown.