### PR TITLE
fix: disables add button when no asset selected

### DIFF
--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -33,7 +33,7 @@ export function ActionBar(props: ActionBarProps) {
         </Button>
         <ImageSelectButton
           hidden={!!props.assets.length}
-          disabled={props.selectedAsset?.src === ''}
+          disabled={!props.selectedAsset}
           handleSubmit={props.handleSubmit}
         />
       </div>

--- a/src/components/ImageSelect/ImageSelect.tsx
+++ b/src/components/ImageSelect/ImageSelect.tsx
@@ -6,7 +6,7 @@ import './ImageSelect.css';
 interface ImageSelectProps {
   handleSubmit: Function; // Called when the button is clicked
   disabled: boolean; // Whether the button is disabled
-  hidden: boolean; // Whether the button is hidden
+  hidden?: boolean; // Whether the button is hidden
 }
 
 export function ImageSelectButton({
@@ -30,7 +30,7 @@ export function ImageSelectButton({
       disabled={disabled}
       onClick={handleClick}
     >
-      Add image
+      Add Selected Asset
     </Button>
   );
 }


### PR DESCRIPTION
# Before
Add image button is enabled even when no asset is selected.

# After
Copy has been updated, Add Asset button is disabled when no asset is selected.

# Screenshots
### Before
<img width="1012" alt="Screen Shot 2022-11-14 at 1 22 51 PM" src="https://user-images.githubusercontent.com/8823474/201737338-91ee03b7-0030-405c-87c6-6c2f88e223d0.png">


### After
<img width="1015" alt="Screen Shot 2022-11-14 at 1 22 09 PM" src="https://user-images.githubusercontent.com/8823474/201737289-60ac0b8c-02f0-4208-902f-4fba434a05c5.png">
