### PR TITLE
fix: construct asset URL using Source `subdomain` instead of `name`

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -288,7 +288,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
    */
   buildAssetWithFullUrl(asset: AssetProps[]) {
     const scheme = 'https://';
-    const domain = this.state.selectedSource.name;
+    const domain = this.state.selectedSource.domain;
     const imgixDomain = '.imgix.net';
 
     const transformedAsset = asset.map((asset) => ({


### PR DESCRIPTION
## Description

Previously, the URL construction logic would use the Source `name` (e.g. `sdk-test` in the screenshot below) to construct the asset URL. This was, however, not ideal as Source names are not always the same as the Source subdomain(s) and therefore, are not guaranteed to conform to the URL spec.

Now, the URL construction logic uses the Source domain, i.e. the first `subdomain` returned by the Sources endpoint, to construct asset URLs.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/15919091/202106286-bc099c8d-4d2c-4d28-825d-a4d823490d0c.png">
 

## Steps to Test

Create a Source whose name contains spaces (or any other URL-unsafe characters) and link it to an origin with assets. From the Contentful dashboard, request the new Source. 

Before this change, the Dialog renders a blank screen and react-imgix will emit several domain validation errors:

```
Error: Domain must be passed in as fully-qualified domain name and should not include a protocol or any path element, i.e. "example.imgix.net".
```

After this change, the Dialog should render all assets normally.

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [ ] ~~Update the readme (if applicable).~~
- [ ] ~~Update or add any necessary API documentation (if applicable)~~
- [x] All existing unit tests are still passing (if applicable).
- [ ] ~~Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).~~
- [ ] ~~Add new passing unit tests to cover the code introduced by your PR (if applicable).~~
- [ ] ~~Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.~~
- [ ] ~~If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.~~