### PR TITLE
feat: display video frame as thumbnail

### DIFF
--- a/src/components/Gallery/GridImage.tsx
+++ b/src/components/Gallery/GridImage.tsx
@@ -28,6 +28,14 @@ export const GridImage: FunctionComponent<GridImageComponentProps> = ({
   const handleOnImageError = () => {
     setImageDidError(true);
   };
+
+  const VideoThumbnail = () => {
+    const url =
+      asset.src.replace('imgix.net', 'imgix.video') +
+      '?video-generate=thumbnail&time=0.1';
+    return url;
+  };
+
   const GridImageAsset = () => {
     return imageDidError ? (
       <ImageAssetSVG />
@@ -46,6 +54,26 @@ export const GridImage: FunctionComponent<GridImageComponentProps> = ({
       />
     );
   };
+
+  const GridVideoAsset = () => {
+    return imageDidError ? (
+      <VideoAssetSVG />
+    ) : (
+      <Imgix
+        src={VideoThumbnail() || ''}
+        width={140}
+        height={125}
+        imgixParams={{
+          auto: 'format',
+          fit: 'crop',
+          crop: 'entropy',
+        }}
+        sizes="(min-width: 480px) calc(12.5vw - 20px)"
+        htmlAttributes={{ onError: handleOnImageError }}
+      />
+    );
+  };
+
   return (
     <div onClick={handleClick} className="ix-gallery-item">
       <div className={'ix-gallery-image-gradient' + focus}></div>
@@ -56,7 +84,7 @@ export const GridImage: FunctionComponent<GridImageComponentProps> = ({
       ) : asset.attributes.content_type.startsWith('image') ? (
         <GridImageAsset />
       ) : asset.attributes.content_type.startsWith('video') ? (
-        <VideoAssetSVG />
+        <GridVideoAsset />
       ) : asset.attributes.content_type.startsWith('text') ? (
         <DocumentAssetSVG />
       ) : asset.attributes.content_type === 'application/pdf' ? (


### PR DESCRIPTION
We leverage the video-generate parameter to use video frames as thumbnails for video assets. We add additional fall-back functionality to use a generic SVG icon for when there's an error rendering the frame.

# Screenshots
### Before
<img width="1285" alt="Screen Shot 2022-11-28 at 2 36 16 PM" src="https://user-images.githubusercontent.com/8823474/204365545-aba622d3-fbdd-43b1-8323-a071bd8137f7.png">

### After
<img width="1275" alt="Screen Shot 2022-11-28 at 2 34 59 PM" src="https://user-images.githubusercontent.com/8823474/204365567-28d852e4-e95e-462d-910c-132dba11e808.png">
