### PR TITLE
fix: strip webp upload headers

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -440,7 +440,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         // convert image file to base64 string
         const assetBase64String = reader.result as string;
         const fileString = assetBase64String.replace(
-          /^data:image\/gif;base64,|^data:image\/png;base64,|^data:image\/jpeg;base64,|^data:image\/jpg;base64,|^data:image\/bmp;base64,/,
+          /^data:image\/gif;base64,|^data:image\/png;base64,|^data:image\/jpeg;base64,|^data:image\/jpg;base64,|^data:image\/bmp;base64,|^data:image\/webp;base64,/,
           '',
         );
         const buffer = Buffer.from(fileString, 'base64');


### PR DESCRIPTION
## Description
Before this commit, webp upload headers were not being removed from the file buffer string, causing incorrect file types on the backend for the image. 

After this commit, webp files upload correctly.