### PR TITLE
fix: prevent upload modal scrolling

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -37,7 +37,7 @@
 }
 
 .ix-upload-editor-container {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
## Before
Before this commit, the upload modal's backdrop was scrollable.

## After
After this commit, its position is fixed and cannot be scrolled.

## 🖼️  Screenshots
Before
![upload-scroll-bg-before](https://user-images.githubusercontent.com/16711614/204850385-8386f7b9-e067-4383-8caf-f941eb906b9d.gif)



After
![scroll-upload-modal-bg](https://user-images.githubusercontent.com/16711614/204848844-9bb23489-a196-474e-b2d7-070f90bf0952.gif)
