### PR TITLE
style: center upload modal

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -51,12 +51,12 @@
   width: 432px;
   height: 574px;
   top: 2.5%;
-  left: 25%;
-  right: 25%;
+  left: 0;
+  right: 0;
   bottom: 0%;
   background-color: #fff;
   z-index: 3;
-  margin: 25px;
+  margin: auto;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## Before
Before this commit, the relative, `25%`, left and right positioning would yield inconsistent "centering" results.

## After
After this commit, the content is centered by using left `0` and right `0` positioning and using auto margins.

## 🖼️ Screenshots
![upload-pos-before](https://user-images.githubusercontent.com/16711614/204851120-51b4616b-307e-4a76-a321-994d6807c4f2.png)
![uploiad-pos-after](https://user-images.githubusercontent.com/16711614/204851118-95fa7b86-e2ce-495c-a17b-44c7bb445ad1.png)
