### PR TITLE
refactor: remove filename form field

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -168,24 +168,17 @@
 }
 
 .ix-upload-preview-filename {
-  /* Font */
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 20px;
-  /* Auto layout */
-
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 8px;
-
-  position: relative;
   width: 384px;
   height: 48px;
+  border-radius: 0px 0px 6px 6px;
   margin: 0 auto;
-  margin-bottom: 10px;
-  border-radius: 0px 0px 6px 6px
+  margin-bottom: 12px;
+  background: #F7F9FA;
+  box-shadow: inset 0px -1px 0px #e7ebee;
 }
 
 .ix-upload-confirm-button {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -475,16 +475,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     this.setDestinationFilePath(value);
   };
 
-  setFilename = (filename: string) => {
-    const uploadForm = { ...this.state.uploadForm, filename: filename };
-    this.setState({ uploadForm });
-  };
-
-  updateFileName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    this.setFilename(value);
-  };
-
   openFileForm = (file: File, previewSource: string, showUpload: boolean) => {
     const uploadForm = {
       ...this.state.uploadForm,

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import {
   SectionHeading,
   Icon,
   Tooltip,
+  Paragraph,
 } from '@contentful/forma-36-react-components';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
@@ -633,14 +634,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                     height={288}
                   />
                   <div className="ix-upload-preview-filename">
-                    <TextInput
-                      className={
-                        this.state.isUploading ? 'ix-input-readonly' : ''
-                      }
-                      value={this.state.uploadForm.filename || ''}
-                      onChange={this.updateFileName}
-                      isReadOnly={this.state.isUploading}
-                    ></TextInput>
+                    <Paragraph>{this.state.uploadForm.filename}</Paragraph>
                   </div>
                 </div>
                 <Button


### PR DESCRIPTION
## Before
Before this commit, the upload asset could be renamed before upload. 

## After
After this commit, the upload asset cannot be renamed.

## 🖼️  Screenshots
before
![filename-field-before](https://user-images.githubusercontent.com/16711614/204851788-956a78e2-dbde-4f9c-8c0c-173cd0fdcfc1.png)
after
![file-name-field-after](https://user-images.githubusercontent.com/16711614/204851796-b20265eb-e611-41d7-a436-bd39a41b76cd.png)

