### PR TITLE
feat: remove webfolder sources from upload sources

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -168,24 +168,17 @@
 }
 
 .ix-upload-preview-filename {
-  /* Font */
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 20px;
-  /* Auto layout */
-
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 8px;
-
-  position: relative;
   width: 384px;
   height: 48px;
+  border-radius: 0px 0px 6px 6px;
   margin: 0 auto;
-  margin-bottom: 10px;
-  border-radius: 0px 0px 6px 6px
+  margin-bottom: 12px;
+  background: #F7F9FA;
+  box-shadow: inset 0px -1px 0px #e7ebee;
 }
 
 .ix-upload-confirm-button {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -475,16 +475,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
     this.setDestinationFilePath(value);
   };
 
-  setFilename = (filename: string) => {
-    const uploadForm = { ...this.state.uploadForm, filename: filename };
-    this.setState({ uploadForm });
-  };
-
-  updateFileName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    this.setFilename(value);
-  };
-
   openFileForm = (file: File, previewSource: string, showUpload: boolean) => {
     const uploadForm = {
       ...this.state.uploadForm,

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import {
   SectionHeading,
   Icon,
   Tooltip,
+  Paragraph,
 } from '@contentful/forma-36-react-components';
 import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
 import ImgixAPI, { APIError } from 'imgix-management-js';
@@ -633,14 +634,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                     height={288}
                   />
                   <div className="ix-upload-preview-filename">
-                    <TextInput
-                      className={
-                        this.state.isUploading ? 'ix-input-readonly' : ''
-                      }
-                      value={this.state.uploadForm.filename || ''}
-                      onChange={this.updateFileName}
-                      isReadOnly={this.state.isUploading}
-                    ></TextInput>
+                    <Paragraph>{this.state.uploadForm.filename}</Paragraph>
                   </div>
                 </div>
                 <Button

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -581,7 +581,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
                     <SourceSelect
                       testId="upload-source-select-dropdown"
                       selectedSource={uploadForm.source || selectedSource}
-                      allSources={allSources}
+                      allSources={allSources.filter(
+                        (source) => source.type !== 'webfolder',
+                      )}
                       setSource={this.setUploadSource}
                       resetErrors={() =>
                         this.resetNErrors(this.state.errors.length)


### PR DESCRIPTION
## Before
Before this commit, it was possible to select a web folder source as an upload source in the upload modal's source select dropdown.

## After
After this commit, the webfolder sources are filtered out of the `allSources` slice of state, and therefore not selectable in that dropdown.