### PR TITLE
feat(field-image): use grid-image placeholders

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -55,6 +55,7 @@ export default class Field extends Component<FieldProps, FieldState> {
     if (this.state.selectedAsset) {
       return (
         <FieldImagePreview
+          contentType={this.state.selectedAsset.attributes.content_type}
           imagePath={this.state.selectedAsset?.src}
           openDialog={this.debounceOpenDialog}
           updateHeight={updateHeightHandler}

--- a/src/components/Field/FieldImagePreview.tsx
+++ b/src/components/Field/FieldImagePreview.tsx
@@ -1,11 +1,17 @@
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 import { Button } from '@contentful/forma-36-react-components';
 import Imgix from 'react-imgix';
 
 import './FieldImagePreview.css';
+import { UnknownAssetSVG } from '../Icons/UnknownAssetSVG';
+import { SVGAssetSVG } from '../Icons/SVGAssetSVG';
+import { DocumentAssetSVG } from '../Icons/DocumentAssetSVG';
+import { PDFAssetSVG } from '../Icons/PDFAssetSVG';
+import { ImageAssetSVG } from '../Icons/ImageAssetSVG';
 
 interface FieldImagePreviewProps {
   imagePath: string;
+  contentType: string;
   updateHeight: Function;
   openDialog: Function;
   clearSelection: Function;
@@ -13,13 +19,22 @@ interface FieldImagePreviewProps {
 
 export function FieldImagePreview({
   imagePath,
+  contentType,
   openDialog,
   updateHeight,
   clearSelection,
 }: FieldImagePreviewProps): ReactElement {
   updateHeight(311);
-  return (
-    <div className="ix-field-image-preview">
+  const [imageDidError, setImageDidError] = useState(false);
+
+  const handleOnImageError = () => {
+    setImageDidError(true);
+  };
+
+  const FieldImage = () =>
+    imageDidError ? (
+      <ImageAssetSVG />
+    ) : (
       <Imgix
         width={230}
         height={230}
@@ -29,7 +44,48 @@ export function FieldImagePreview({
           fit: 'crop',
           crop: 'entropy',
         }}
+        htmlAttributes={{ onError: handleOnImageError }}
       />
+    );
+
+  const FieldVideo = () =>
+    imageDidError ? (
+      <ImageAssetSVG />
+    ) : (
+      <Imgix
+        src={
+          imagePath.replace('imgix.net', 'imgix.video') +
+          '?video-generate=thumbnail&time=0.1'
+        }
+        width={140}
+        height={125}
+        imgixParams={{
+          auto: 'format',
+          fit: 'crop',
+          crop: 'entropy',
+        }}
+        sizes="(min-width: 480px) calc(12.5vw - 20px)"
+        htmlAttributes={{ onError: handleOnImageError }}
+      />
+    );
+
+  return (
+    <div className="ix-field-image-preview">
+      {!contentType ? (
+        <UnknownAssetSVG />
+      ) : contentType.startsWith('image/svg') ? (
+        <SVGAssetSVG />
+      ) : contentType.startsWith('image') ? (
+        <FieldImage />
+      ) : contentType.startsWith('video') ? (
+        <FieldVideo />
+      ) : contentType.startsWith('text') ? (
+        <DocumentAssetSVG />
+      ) : contentType === 'application/pdf' ? (
+        <PDFAssetSVG />
+      ) : (
+        <UnknownAssetSVG />
+      )}
       <div className="ix-field-image-preview-buttons">
         <Button
           className="ix-field-image-preview-buttons-replace"


### PR DESCRIPTION
## Before
Before this commit, un-renderable images were displayed as broken.

## After
After this commit, un-renderable images use the same fallback logic as the `GridImage` component.

## 🖼️  Screenshots
before
![field-preview-before](https://user-images.githubusercontent.com/16711614/204853646-06295d0f-e863-480a-9788-f1a0d4468c0a.png)

after
![field-preview-after](https://user-images.githubusercontent.com/16711614/204853677-f82c9f1e-5733-48ef-a868-dc45e9f7385a.png)
![field-preview-after-2](https://user-images.githubusercontent.com/16711614/204853694-76fb3e55-5149-44fc-941d-706757eacc0c.png)


