### PR TITLE
fix: decrease toast notifications offset

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -401,7 +401,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       .then(
         (_resp) => {
           this.setState({ isUploading: false, showUpload: false });
-          Notification.setPosition('top', { offset: 650 });
+          Notification.setPosition('top', { offset: 565 });
           Notification.success('File successfully uploaded to imgix Source.', {
             duration: 50000,
             id: 'ix-dialog-notification',
@@ -420,7 +420,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           // a property or index that does not exist.
           const reason = errorResponse?.errors[0]?.detail;
           console.error('imgix: upload error', error.response);
-          Notification.setPosition('top', { offset: 650 });
+          Notification.setPosition('top', { offset: 565 });
           Notification.error(`Upload failed: ${reason}`, {
             duration: 10000,
             id: 'ix-dialog-notification',


### PR DESCRIPTION
## Before
Before this commit, the error and success toasts were rendered outside the modal in an invisible space. This was because the `offset` value was based off of an AM modal that used to be larger.

## After
After this commit, the `offset` is set to `565` making toasts visible again.

## 🖼️ Screenshots

https://user-images.githubusercontent.com/16711614/204858291-9a36316d-2948-4146-a9c6-bb2af2d19d5d.mp4

