### PR TITLE
fix: bugs related to state persistence

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -217,7 +217,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   debounceSearchOnClick = debounce(this.searchOnClick, 1000, { leading: true });
 
   setSelectedSource = (source: SourceProps) => {
-    this.setState({ selectedSource: source });
+    this.setState({ selectedSource: source, page: {
+      currentIndex: 0,
+      totalPageCount: 0,
+    } });
   };
 
   resetNErrors = (n: number = 1) => {
@@ -337,10 +340,10 @@ export default class Dialog extends Component<DialogProps, DialogState> {
    * Requests and constructs fully-qualified image URLs, saving the results to
    * state
    */
-  requestImageUrls = async (query?: string) => {
+  requestImageUrls = async (query?: string, currentIndex?: number) => {
     // if selected source, return assets
     if (Object.keys(this.state.selectedSource).length) {
-      const defaultQuery = `?page[number]=${this.state.page.currentIndex}&page[size]=18`;
+      const defaultQuery = `?page[number]=${currentIndex || this.state.page.currentIndex}&page[size]=18`;
 
       const assetObjects = query
         ? await this.getAssetObjects(query, noSearchAssetsError())
@@ -501,7 +504,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       (this.state.page.currentIndex !== prevState.page.currentIndex &&
         !this.state.isSearching)
     ) {
-      this.requestImageUrls();
+      this.requestImageUrls(undefined, 0);
     }
   }
 

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -34,6 +34,14 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     this.props.sdk.close(this.state.selectedAsset);
   };
 
+  componentDidUpdate(prevProps: GalleryProps) {
+    if (prevProps.selectedSource.id !== this.props.selectedSource.id) {
+      this.setState({
+        selectedAsset: undefined,
+      });
+    }
+  }
+
   render() {
     const { selectedAsset } = this.state;
     if (!this.props.assets.length) {


### PR DESCRIPTION
## Description

This PR addresses two main issues:
- When changing between Sources, the page's `currentIndex` persists between the change. This can cause an issue where the app will try to render a page of assets on a source where that page doesn't exist. Now, we will reset the `currentIndex` to the first page of assets to avoid this issue.
- When changing between Sources, the previously `selectedAsset` persists between the change. This means that a user can select an asset from one source, change their mind, selected a different source, and this be able the add the previously selected asset from the aforementioned source. Now, the `selectedAsset` is reset between different Sources.

### Before

https://user-images.githubusercontent.com/15919091/204931593-09316ff2-f79d-42da-8fe0-d2f7fe7dbfd9.mp4

### After

https://user-images.githubusercontent.com/15919091/204930693-71db5648-7625-42c9-ac28-8b7d99f2095f.mp4

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [ ] ~~Update the readme (if applicable).~~
- [ ] ~~Update or add any necessary API documentation (if applicable)~~
- [x] All existing unit tests are still passing (if applicable).
- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [ ] ~~Add new passing unit tests to cover the code introduced by your PR (if applicable).~~
- [ ] ~~Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.~~
- [ ] ~~If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.~~