### PR TITLE
docs: add upload docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A Contentful app that integrates with imgix's [Asset Manager](https://docs.imgix
 - [Add to Content Model](#add-to-content-model)
 - [Browse and Select Assets](#browse-and-select-assets)
 - [Search for Assets](#search-for-assets)
+- [Upload Assets](#upload-assets)
 - [Query an Asset](#query-an-asset)
   - [Transforming Assets](#transforming-assets)
   - [Metadata](#metadata)
@@ -113,6 +114,19 @@ https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-
 <!-- /ix-docs-ignore -->
 <video controls width="800" height="600">
   <source src="https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov">
+</video>
+
+## Upload Assets
+
+The imgix app enables users to upload assets to a source. Using the "Upload" button near the top of the modal, users can select an image to upload to their desired source. Users change the upload source destination, filepath, or filename. To learn more about uploading, see our Asset Manager [documentation](https://docs.imgix.com/setup/asset-manager).
+
+<!-- ix-docs-ignore -->
+https://user-images.githubusercontent.com/16711614/205107815-9d576fd8-530a-41c0-99fa-0e3800b3e896.mp4
+
+<!-- /ix-docs-ignore -->
+<video controls width="800" height="600">
+  <source src="https://user-images.githubusercontent.com/16711614/205107815-9d576fd8-530a-41c0-99fa-0e3800b3e896.mp4
+">
 </video>
 
 ## Query an Asset

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-
 
 ## Upload Assets
 
+> note: uploading to web folder sources is not supported at this time.
+
 The imgix app enables users to upload assets to a source. Using the "Upload" button near the top of the modal, users can select an image to upload to their desired source. Users change the upload source destination, filepath, or filename. To learn more about uploading, see our Asset Manager [documentation](https://docs.imgix.com/setup/asset-manager).
 
 <!-- ix-docs-ignore -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
-A Contentful app that integrates with imgix's [Image Manager](https://docs.imgix.com/setup/image-manager). Browse, search, and insert image assets into your content quickly and easily. Simplify your content editing workflow within Contentful and empower your developers with imgix’s powerful image rendering and optimization service.
+A Contentful app that integrates with imgix's [Asset Manager](https://docs.imgix.com/setup/asset-manager). Browse, search, and insert assets into your content quickly and easily. Simplify your content editing workflow within Contentful and empower your developers with imgix’s powerful image rendering and optimization service.
 
 [![npm version](https://img.shields.io/npm/v/@imgix/contentful.svg)](https://www.npmjs.com/package/@imgix/contentful)
 [![Build Status](https://circleci.com/gh/imgix/contentful.svg?style=shield)](https://circleci.com/gh/imgix/contentful)
@@ -25,10 +25,10 @@ A Contentful app that integrates with imgix's [Image Manager](https://docs.imgix
 - [Configuration](#configuration)
   - [Assign to Fields (Optional)](#assign-to-fields-optional)
 - [Add to Content Model](#add-to-content-model)
-- [Browse and Select Images](#browse-and-select-images)
-- [Search for Images](#search-for-images)
-- [Query an Image](#query-an-image)
-  - [Transforming Images](#transforming-images)
+- [Browse and Select Assets](#browse-and-select-assets)
+- [Search for Assets](#search-for-assets)
+- [Query an Asset](#query-an-asset)
+  - [Transforming Assets](#transforming-assets)
   - [Metadata](#metadata)
 - [License](#license)
 
@@ -89,9 +89,9 @@ https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-
   <source src="https://user-images.githubusercontent.com/15919091/137056289-8ee117fa-c254-4ae9-93aa-0bea3b975d1b.mp4">
 </video>
 
-## Browse and Select Images
+## Browse and Select Assets
 
-From any instance of a field using the imgix app, a modal can be opened to browse images by imgix source. First, select a desired source to browse images from. Using any of the pagination buttons, navigate each page of assets to choose from. After selecting an image, it can be inserted to the field via the `Add image` button. Additionally, there are options to replace an image, or clear a selection from the field altogether.
+From any instance of a field using the imgix app, a modal can be opened to browse assets by imgix source. First, select a desired source to browse assets from. Using any of the pagination buttons, navigate each page of assets to choose from. After selecting an asset, it can be inserted to the field via the `Add asset` button. Additionally, there are options to replace an asset, or clear a selection from the field altogether.
 
 <!-- ix-docs-ignore -->
 
@@ -102,9 +102,9 @@ https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-
   <source src="https://user-images.githubusercontent.com/15919091/137056329-97e3536d-2bf3-471e-970a-2921fab44e8d.mp4">
 </video>
 
-## Search for Images
+## Search for Assets
 
-The imgix app enables users to conduct a keyword search across assets in a source. Using the search box near the top of the modal will execute a search across multiple pre-determined fields: file origin path, image tags, and categories. To learn more about these fields, see our Asset Manager [documentation](https://docs.imgix.com/setup/image-manager#image-details).
+The imgix app enables users to conduct a keyword search across assets in a source. Using the search box near the top of the modal will execute a search across multiple pre-determined fields: file origin path, asset tags, and categories. To learn more about these fields, see our Asset Manager [documentation](https://docs.imgix.com/setup/asset-manager#image-details).
 
 <!-- ix-docs-ignore -->
 
@@ -115,9 +115,9 @@ https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-
   <source src="https://user-images.githubusercontent.com/15919091/141595662-3a9a98fd-aa88-4e56-8d6f-c30a782c678b.mov">
 </video>
 
-## Query an Image
+## Query an Asset
 
-Once the content is published, developers can query the `src` of the selected image, returned as a string, via the Contentful API. The example below demonstrates this using GraphQL, but this can be done independent of any specific tool.
+Once the content is published, developers can query the `src` of the selected asset, returned as a string, via the Contentful API. The example below demonstrates this using GraphQL, but this can be done independent of any specific tool.
 
 ```graphql
 query MyQuery {
@@ -156,9 +156,9 @@ returns something similar to:
 }
 ```
 
-### Transforming Images
+### Transforming Assets
 
-Developers can leverage the power of imgix's [rendering API](https://docs.imgix.com/apis/rendering) downstream from where the image was selected in Contentful. We recommend piping the value of the `src` field of the image through to one of imgix's [SDKs](https://docs.imgix.com/libraries#frontend-libraries). The example below builds on the previous one by passing the image `src` through to [@imgix/gatsby](https://github.com/imgix/gatsby) component:
+Developers can leverage the power of imgix's [rendering API](https://docs.imgix.com/apis/rendering) downstream from where the asset was selected in Contentful. We recommend piping the value of the `src` field of the asset through to one of imgix's [SDKs](https://docs.imgix.com/libraries#frontend-libraries). The example below builds on the previous one by passing the image `src` through to [@imgix/gatsby](https://github.com/imgix/gatsby) component:
 
 ```js
 import React from 'react';
@@ -196,8 +196,8 @@ export const query = graphql`
 ```
 
 ### Metadata
-
-Users may also access metadata associated with an image via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/image-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
+s
+Users may also access metadata associated with an asset via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/asset-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
 
 ```graphql
 query MyQuery {
@@ -354,6 +354,3 @@ export const query = graphql`
 `;
 ```
 
-## License
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fimgix%2Fcontentful.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fimgix%2Fcontentful?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ export const query = graphql`
 ```
 
 ### Metadata
-s
+
 Users may also access metadata associated with an asset via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/asset-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
 
 ```graphql


### PR DESCRIPTION
This PR replaces all instances of `image manager` with `asset manager` and many instances of `image` with `asset` in the `README.md.` It also adds a section about the upload capabilities.


### Upload demo video
https://user-images.githubusercontent.com/16711614/205107815-9d576fd8-530a-41c0-99fa-0e3800b3e896.mp4



