### PR TITLE
feat: add loading spinner to source dropdown

### DIFF
--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -5,6 +5,8 @@ import {
   Dropdown,
   DropdownList,
   DropdownListItem,
+  Paragraph,
+  Spinner,
 } from '@contentful/forma-36-react-components';
 
 import { SourceProps } from '../Dialog';
@@ -53,6 +55,11 @@ export function SourceSelectDropdown({
       }
     >
       <DropdownList className="ix-dropdown-list">
+        {!allSources.length ? (
+          <Paragraph style={{ paddingLeft: 5 }}>
+            Loading <Spinner />
+          </Paragraph>
+        ) : null}
         {allSources.map((source: SourceProps) => (
           <DropdownListItem key={source.id} onClick={() => handleClick(source)}>
             {source.name}


### PR DESCRIPTION
## Description
This PR adds a `<Spinner />` to the source select dropdown that renders whenever `allSources.length` is falsy.

## Screenshots

https://user-images.githubusercontent.com/16711614/205399840-e03a8120-66bc-442e-a905-e88073f24fcf.mp4

