### PR TITLE
feat: show loading spinner on source change

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -52,6 +52,7 @@ interface DialogState {
   errors: IxError[]; // array of IxErrors if any
   isSearching: boolean;
   isUploading: boolean;
+  loading: boolean;
   showUpload: boolean;
   uploadForm: {
     file?: File;
@@ -110,6 +111,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       errors: [],
       isSearching: false,
       isUploading: false,
+      loading: false,
       showUpload: false,
       uploadForm: {},
     };
@@ -182,6 +184,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         totalPageCount,
       },
       errors,
+      loading: false,
     });
   };
 
@@ -370,6 +373,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         this.setState({
           assets,
           isSearching: false,
+          loading: false,
         });
       } else {
         this.setState({ assets: [] });
@@ -433,7 +437,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             id: 'ix-dialog-notification',
           });
           // We're not adding this error to state because `errors` in state is used as a UI fallback, not a notification message.
-          this.setState({ isUploading: false, showUpload: false });
+          this.setState({
+            isUploading: false,
+            showUpload: false,
+            loading: false,
+          });
         },
       );
   };
@@ -509,6 +517,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       (this.state.page.currentIndex !== prevState.page.currentIndex &&
         !this.state.isSearching)
     ) {
+      this.setState({ loading: true });
       this.requestImageUrls(undefined, 0);
     }
   }
@@ -565,6 +574,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           pageInfo={page}
           changePage={this.debounceHandlePageChange}
           assets={assets}
+          loading={this.state.loading}
         />
         {/* { UI Error fallback } */}
         {this.state.errors.length > 0 && (

--- a/src/components/Gallery/GalleryPlaceholder.tsx
+++ b/src/components/Gallery/GalleryPlaceholder.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { Paragraph } from '@contentful/forma-36-react-components';
+import { Paragraph, Spinner } from '@contentful/forma-36-react-components';
 import { ActionBar } from '../ActionBar';
 import './ImagePlaceholder.css';
 
@@ -14,6 +14,7 @@ export function GalleryPlaceholder({
     <div className="ix-grid-item-placeholder">
       <Paragraph className="ix-placeholder-text">{text}</Paragraph>
       <ActionBar handleClose={sdk.close} />
+      {text === 'Loading' ? <Spinner /> : null}
     </div>
   );
 }

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -13,6 +13,7 @@ interface GalleryProps {
   pageInfo: PageProps;
   changePage: (newPageIndex: number) => void;
   assets: AssetProps[];
+  loading: boolean;
 }
 
 interface GalleryState {
@@ -44,7 +45,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
 
   render() {
     const { selectedAsset } = this.state;
-    if (!this.props.assets.length) {
+    if (!this.props.assets.length && !this.props.loading) {
       return !this.props.selectedSource.type ? (
         <GalleryPlaceholder
           sdk={this.props.sdk}
@@ -61,6 +62,8 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
           text="Add assets to this Source by selecting Upload."
         />
       );
+    } else if (this.props.loading) {
+      return <GalleryPlaceholder sdk={this.props.sdk} text="Loading" />;
     }
 
     return (


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
This PR adds a `loading` slice of state that controls whether or not the `GalleryPlaceholder` component shows a `Spinner` while a new source's assets are being requested. When assets are still being loaded, placeholder text that says `Loading` will now be displayed alongside a loading `Spinner`.

A future PR should address how many slices of the state control asset loading behavior. But that work is out of scope for this PR

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
Irrelevant loading text was displayed when assets were loading.

<!-- After this PR... -->
## After
A loading spinner with placeholder "Loading" text is displayed.

## Screenshots

https://user-images.githubusercontent.com/16711614/205690841-549e3261-1463-4e56-9595-50c105a01d8d.mp4


