### PR TITLE
feat: keep previously selected asset populated

### DIFF
--- a/src/components/Gallery/GalleryPlaceholder.tsx
+++ b/src/components/Gallery/GalleryPlaceholder.tsx
@@ -6,14 +6,16 @@ import './ImagePlaceholder.css';
 export function GalleryPlaceholder({
   text,
   sdk,
+  handleClose,
 }: {
   text: string;
   sdk: any;
+  handleClose: () => void;
 }): ReactElement {
   return (
     <div className="ix-grid-item-placeholder">
       <Paragraph className="ix-placeholder-text">{text}</Paragraph>
-      <ActionBar handleClose={sdk.close} />
+      <ActionBar handleClose={handleClose} />
       {text === 'Loading' ? <Spinner /> : null}
     </div>
   );

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -38,6 +38,12 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     });
   };
 
+  handleClose = () => {
+    this.props.sdk.close({
+      ...(this.props.sdk.parameters.invocation as any)?.selectedImage,
+    });
+  };
+
   componentDidUpdate(prevProps: GalleryProps) {
     if (prevProps.selectedSource.id !== this.props.selectedSource.id) {
       this.setState({
@@ -52,21 +58,30 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
       return !this.props.selectedSource.type ? (
         <GalleryPlaceholder
           sdk={this.props.sdk}
+          handleClose={this.handleClose}
           text="Select a Source to view your image gallery"
         />
       ) : this.props.selectedSource.type === 'webfolder' ? (
         <GalleryPlaceholder
           sdk={this.props.sdk}
+          handleClose={this.handleClose}
           text="Select a different Source to view your visual media."
         />
       ) : (
         <GalleryPlaceholder
           sdk={this.props.sdk}
+          handleClose={this.handleClose}
           text="Add assets to this Source by selecting Upload."
         />
       );
     } else if (this.props.loading) {
-      return <GalleryPlaceholder sdk={this.props.sdk} text="Loading" />;
+      return (
+        <GalleryPlaceholder
+          handleClose={this.handleClose}
+          sdk={this.props.sdk}
+          text="Loading"
+        />
+      );
     }
 
     return (
@@ -90,7 +105,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
           selectedAsset={selectedAsset}
           pageInfo={this.props.pageInfo}
           changePage={this.props.changePage}
-          handleClose={this.props.sdk.close}
+          handleClose={this.handleClose}
         />
       </>
     );


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
This PR ensures the contentful field is not cleared when a user clicks "cancel" on the modal.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
`sdk.close()` would get called without the previously selected asset as an argument, clearing the field.
<!-- After this PR... -->
## After
`sdk.close({...prevAsset})` gets called with the previously selected asset as an argument, preserving the previously value for the field.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Screenshots

https://user-images.githubusercontent.com/16711614/206019039-52ab59f1-fc58-4769-a39e-f110019dfd0d.mp4


