### PR TITLE
refactor: show loading on replace

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -250,11 +250,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       }
       // check if previously selected source exists
       // if it does, add it to state.
-      const previouslySelectedSourceID = (
+      const previouslySelectedSource = (
         this.props.sdk.parameters.invocation as AppInvocationParameters
-      )?.selectedImage?.selectedSourceId;
+      )?.selectedImage?.selectedSource;
+
       const selectedSource = sources.find((source: any) => {
-        return source.id === previouslySelectedSourceID;
+        return source.id === previouslySelectedSource?.id;
       });
       if (selectedSource) {
         this.setState({ allSources: sources, selectedSource });
@@ -537,8 +538,14 @@ export default class Dialog extends Component<DialogProps, DialogState> {
   }
 
   render() {
-    const { selectedSource, allSources, page, assets, uploadForm } = this.state;
+    const { allSources, page, assets, uploadForm } = this.state;
     const sdk = this.props.sdk;
+    const previouslySelectedSource = (
+      sdk.parameters.invocation as AppInvocationParameters
+    )?.selectedImage?.selectedSource;
+    const selectedSource = this.state.selectedSource.id
+      ? this.state.selectedSource
+      : previouslySelectedSource || {};
 
     return (
       <div className="ix-container">
@@ -552,7 +559,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
             setSource={this.setSelectedSource}
             resetErrors={() => this.resetNErrors(this.state.errors.length)}
           />
-          {this.state.selectedSource.id && (
+          {selectedSource?.id && (
             <div className="ix-top-bar-container">
               <Form className="ix-searchForm">
                 <TextInput

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -52,7 +52,7 @@ export default class Field extends Component<FieldProps, FieldState> {
 
   render() {
     const updateHeightHandler = this.props.sdk.window.updateHeight;
-    if (this.state.selectedAsset) {
+    if (this.state.selectedAsset && this.state.selectedAsset.src) {
       return (
         <FieldImagePreview
           contentType={this.state.selectedAsset.attributes.content_type}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -58,18 +58,11 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
       this.props.sdk.parameters.invocation as any
     )?.selectedImage?.selectedSource;
 
-    if (this.props.loading) {
-      return (
-        <GalleryPlaceholder
-          handleClose={this.handleClose}
-          sdk={this.props.sdk}
-          text="Loading"
-        />
-      );
-    }
-
-    // If replacing an image
-    if (previouslySelectedSource && !this.props.assets.length) {
+    // If replacing an image or `loading` is true
+    if (
+      (previouslySelectedSource && !this.props.assets.length) ||
+      this.props.loading
+    ) {
       return (
         <GalleryPlaceholder
           handleClose={this.handleClose}

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -34,7 +34,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
   handleSubmit = () => {
     this.props.sdk.close({
       ...this.state.selectedAsset,
-      selectedSourceId: this.props.selectedSource.id,
+      selectedSource: this.props.selectedSource,
     });
   };
 
@@ -54,32 +54,53 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
 
   render() {
     const { selectedAsset } = this.state;
-    if (!this.props.assets.length && !this.props.loading) {
+    const previouslySelectedSource = (
+      this.props.sdk.parameters.invocation as any
+    )?.selectedImage?.selectedSource;
+
+    if (this.props.loading) {
+      return (
+        <GalleryPlaceholder
+          handleClose={this.handleClose}
+          sdk={this.props.sdk}
+          text="Loading"
+        />
+      );
+    }
+
+    // If replacing an image
+    if (previouslySelectedSource && !this.props.assets.length) {
+      return (
+        <GalleryPlaceholder
+          handleClose={this.handleClose}
+          sdk={this.props.sdk}
+          text="Loading"
+        />
+      );
+    }
+
+    // If no asset in state
+    if (!this.props.assets.length) {
+      // If a source hasn't been selected
       return !this.props.selectedSource.type ? (
         <GalleryPlaceholder
           sdk={this.props.sdk}
           handleClose={this.handleClose}
           text="Select a Source to view your image gallery"
         />
-      ) : this.props.selectedSource.type === 'webfolder' ? (
+      ) : // If the source is a webfolder
+      this.props.selectedSource.type === 'webfolder' ? (
         <GalleryPlaceholder
           sdk={this.props.sdk}
           handleClose={this.handleClose}
           text="Select a different Source to view your visual media."
         />
       ) : (
+        // If the source is empty
         <GalleryPlaceholder
           sdk={this.props.sdk}
           handleClose={this.handleClose}
           text="Add assets to this Source by selecting Upload."
-        />
-      );
-    } else if (this.props.loading) {
-      return (
-        <GalleryPlaceholder
-          handleClose={this.handleClose}
-          sdk={this.props.sdk}
-          text="Loading"
         />
       );
     }


### PR DESCRIPTION
## Description
This PR expands on #191, loading previously selected source, to show the previously selected source name in the source dropdown and a loading screen while the sources assets load.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->


## Before
Opening the modal with a pre-selected asset would not show a "loading" placeholder or the pre-selected source, but rather it would show irrelevant placeholder text and a "select source" button.

## After this PR
Opening the modal with a pre-selected asset shows the pre-selected source name in the dropdown and shows a loading screen while the source's assets load

## Screenshots

https://user-images.githubusercontent.com/16711614/206080041-d469db7d-1487-4faa-adf1-150acf7f413e.mov

