### PR TITLE
fix: loading indicator when no assets present in source

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -391,7 +391,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
           loading: false,
         });
       } else {
-        this.setState({ assets: [] });
+        this.setState({ assets: [], loading: false });
       }
     }
   };

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -37,12 +37,11 @@ export default class Field extends Component<FieldProps, FieldState> {
         },
       })
       .then((selectedAsset) => {
-        if (!selectedAsset) {
-          return;
+        if (selectedAsset) {
+          return this.setState({ selectedAsset }, () =>
+            this.props.sdk.field.setValue(selectedAsset),
+          );
         }
-        return this.setState({ selectedAsset }, () =>
-          this.props.sdk.field.setValue(selectedAsset),
-        );
       });
   };
   debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -36,11 +36,14 @@ export default class Field extends Component<FieldProps, FieldState> {
           selectedImage: this.state.selectedAsset,
         },
       })
-      .then((selectedAsset) =>
-        this.setState({ selectedAsset }, () =>
+      .then((selectedAsset) => {
+        if (!selectedAsset) {
+          return;
+        }
+        return this.setState({ selectedAsset }, () =>
           this.props.sdk.field.setValue(selectedAsset),
-        ),
-      );
+        );
+      });
   };
   debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });
 

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -39,9 +39,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
   };
 
   handleClose = () => {
-    this.props.sdk.close({
-      ...(this.props.sdk.parameters.invocation as any)?.selectedImage,
-    });
+    this.props.sdk.close();
   };
 
   componentDidUpdate(prevProps: GalleryProps) {

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -60,7 +60,9 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
 
     // If replacing an image or `loading` is true
     if (
-      (previouslySelectedSource && !this.props.assets.length) ||
+      (previouslySelectedSource &&
+        previouslySelectedSource.id === this.props.selectedSource.id &&
+        !this.props.assets.length) ||
       this.props.loading
     ) {
       return (

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -58,8 +58,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
 
     // If replacing an image or `loading` is true
     if (
-      (previouslySelectedSource &&
-        previouslySelectedSource.id === this.props.selectedSource.id &&
+      (previouslySelectedSource?.id === this.props.selectedSource.id &&
         !this.props.assets.length) ||
       this.props.loading
     ) {


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
Fix loading indicator hang on source select change.
<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
Before this commit, sometimes the loading indicator would stick around even though loading was done. This was because we were not checking if the previously selected source and current source ID matched. This meant that, when they did not, we still treated a source select change as an image replacement.
<!-- After this PR... -->
## After
After this commit, the loading indicator goes away on a new source select after the assets have been requested.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Screenshots

https://user-images.githubusercontent.com/16711614/206595085-c62e11e0-ebe1-47f4-afe3-dc83b17ba2c0.mov

