### PR TITLE
fix: clear on click away

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -37,12 +37,11 @@ export default class Field extends Component<FieldProps, FieldState> {
         },
       })
       .then((selectedAsset) => {
-        if (!selectedAsset) {
-          return;
+        if (selectedAsset) {
+          return this.setState({ selectedAsset }, () =>
+            this.props.sdk.field.setValue(selectedAsset),
+          );
         }
-        return this.setState({ selectedAsset }, () =>
-          this.props.sdk.field.setValue(selectedAsset),
-        );
       });
   };
   debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -36,11 +36,14 @@ export default class Field extends Component<FieldProps, FieldState> {
           selectedImage: this.state.selectedAsset,
         },
       })
-      .then((selectedAsset) =>
-        this.setState({ selectedAsset }, () =>
+      .then((selectedAsset) => {
+        if (!selectedAsset) {
+          return;
+        }
+        return this.setState({ selectedAsset }, () =>
           this.props.sdk.field.setValue(selectedAsset),
-        ),
-      );
+        );
+      });
   };
   debounceOpenDialog = debounce(this.openDialog, 1000, { leading: true });
 

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -39,9 +39,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
   };
 
   handleClose = () => {
-    this.props.sdk.close({
-      ...(this.props.sdk.parameters.invocation as any)?.selectedImage,
-    });
+    this.props.sdk.close();
   };
 
   componentDidUpdate(prevProps: GalleryProps) {


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
This PR fixes an issue where the `<Field />` was cleared whenever a user clicked away from the modal.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
Before this PR, `openCurrentApp` resolved in a way that cleared state when `selectedAsset` was `null` or `undefined`.
<!-- After this PR... -->
## After
After this PR, `openCurrentApp` doesn't call `this.setState()` unless `selectedAsset` evaluates to true.

## Screenhots

https://user-images.githubusercontent.com/16711614/206614608-b06613e3-edc3-4820-af5a-b6b5647f9418.mov


