### PR TITLE
feat: add asset metadata on select

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ export const query = graphql`
 
 ### Metadata
 
-Users may also access metadata associated with an asset via the `attributes` field. Refer to the [imgix documentation](https://docs.imgix.com/setup/asset-manager#:~:text=per%20device/browser.-,Metadata,-This%20section%20displays) to learn more about the various types of metadata available on images and how to use them.
+Users may also access metadata associated with an asset via the `attributes` field. Refer to the [imgix documentation metadata](https://docs.imgix.com/getting-started/setup/asset-manager#metadata) to learn more about the various types of metadata available on images and how to use them.
 
 ```graphql
 query MyQuery {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "contentful-ui-extensions-sdk": "^3.31.0",
         "cross-env": "^7.0.3",
         "imgix-management-js": "^1.3.0",
+        "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "contentful-ui-extensions-sdk": "^3.31.0",
     "cross-env": "^7.0.3",
     "imgix-management-js": "^1.3.0",
+    "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -308,9 +308,9 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         : [assets.data];
       assetObjects = assetsArray.map((asset: any) => {
         stringifyJsonFields(asset, [
-          'custom_fields',
-          'tags',
-          'colors.dominant_colors',
+          'attributes.custom_fields',
+          'attributes.tags',
+          'attributes.colors.dominant_colors',
         ]);
         // TODO: add more explicit types for `asset`
         return {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -30,6 +30,7 @@ import { SourceSelect } from '../SourceSelect/';
 import packageJson from '../../../package.json';
 import { UploadButton } from '../UploadButton/UploadButton';
 import './Dialog.css';
+import { stringifyJsonFields } from '../../helpers/utils';
 
 interface DialogProps {
   sdk: DialogExtensionSDK;
@@ -306,7 +307,11 @@ export default class Dialog extends Component<DialogProps, DialogState> {
         ? assets.data
         : [assets.data];
       assetObjects = assetsArray.map((asset: any) => {
-        this.stringifyJsonFields(asset);
+        stringifyJsonFields(asset, [
+          'custom_fields',
+          'tags',
+          'colors.dominant_colors',
+        ]);
         // TODO: add more explicit types for `asset`
         return {
           src: asset.attributes.origin_path,
@@ -317,28 +322,6 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       return assetObjects;
     } else {
       return [];
-    }
-  };
-
-  /*
-   * Stringifies all JSON field values within the asset.attribute object
-   */
-  stringifyJsonFields = (asset: AssetProps) => {
-    const replaceNullWithEmptyString = (_: any, value: any) =>
-      value === null ? '' : value;
-    asset.attributes.custom_fields = JSON.stringify(
-      asset.attributes.custom_fields,
-      replaceNullWithEmptyString,
-    );
-    asset.attributes.tags = JSON.stringify(
-      asset.attributes.tags,
-      replaceNullWithEmptyString,
-    );
-    if (asset.attributes.colors?.dominant_colors) {
-      asset.attributes.colors.dominant_colors = JSON.stringify(
-        asset.attributes.colors?.dominant_colors,
-        replaceNullWithEmptyString,
-      );
     }
   };
 

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -48,14 +48,21 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     // add metadata to selectedAsset attributes
     const metadata = await this.getAssetMetadata(this.state.selectedAsset.src);
     const selectedAsset = { ...this.state.selectedAsset };
-    const assetAttributes = stringifyJsonFields(
-      { ...selectedAsset.attributes, ...metadata },
-      ['custom_fields', 'tags', 'colors.dominant_colors'],
-    );
-    selectedAsset.attributes = assetAttributes;
+
+    if (!selectedAsset.attributes.media_width) {
+      selectedAsset.attributes.media_width = metadata.PixelWidth;
+    }
+
+    if (!selectedAsset.attributes.media_height) {
+      selectedAsset.attributes.media_hight = metadata.PixelHeight;
+    }
 
     this.props.sdk.close({
-      ...selectedAsset,
+      ...stringifyJsonFields(selectedAsset, [
+        'attributes.custom_fields',
+        'attributes.tags',
+        'attributes.colors.dominant_colors',
+      ]),
       selectedSource: this.props.selectedSource,
     });
   };

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -54,7 +54,7 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
     }
 
     if (!selectedAsset.attributes.media_height) {
-      selectedAsset.attributes.media_hight = metadata.PixelHeight;
+      selectedAsset.attributes.media_height = metadata.PixelHeight;
     }
 
     this.props.sdk.close({

--- a/src/helpers/utils.spec.ts
+++ b/src/helpers/utils.spec.ts
@@ -201,15 +201,16 @@ describe('paramsReducer', () => {
 describe('stringifyJsonFields', () => {
   it('should stringify specified fields', () => {
     const input = {
-      field1: { a: 1, b: 2 },
+      field1: { a: 1, b: null },
       field2: { c: 3, d: 4 },
     };
-    const fields = ['field1', 'field2'];
+    const fields = ['field1.b', 'field2'];
     const output = stringifyJsonFields(input, fields);
 
-    expect(output.field1).toBe(
-      JSON.stringify({ a: 1, b: 2 }, replaceNullWithEmptyString),
-    );
+    expect(output.field1).toStrictEqual({
+      a: 1,
+      b: JSON.stringify('', replaceNullWithEmptyString),
+    });
     expect(output.field2).toBe(
       JSON.stringify({ c: 3, d: 4 }, replaceNullWithEmptyString),
     );
@@ -260,5 +261,18 @@ describe('stringifyJsonFields', () => {
     const output = stringifyJsonFields(input, fields);
 
     expect(output).toEqual(input);
+  });
+
+  it('should not mutate the input object', () => {
+    const input = {
+      field1: { a: 1 },
+      field2: { b: null },
+    };
+    const copy = { ...input };
+    const fields = ['field2'];
+    const output = stringifyJsonFields(input, fields);
+
+    expect(output.field2).toEqual(JSON.stringify({ b: '' }));
+    expect(input).toEqual(copy);
   });
 });

--- a/src/helpers/utils.spec.ts
+++ b/src/helpers/utils.spec.ts
@@ -3,6 +3,8 @@ import {
   groupParamsByKey,
   paramsReducer,
   removeParams,
+  replaceNullWithEmptyString,
+  stringifyJsonFields,
 } from './utils';
 
 describe('groupParamsByKey', () => {
@@ -193,5 +195,70 @@ describe('paramsReducer', () => {
       const updatedParams = paramsReducer(existingParams, newParams, 'remove');
       expect(updatedParams.toString()).toBe('auto=format&fit=crop');
     });
+  });
+});
+
+describe('stringifyJsonFields', () => {
+  it('should stringify specified fields', () => {
+    const input = {
+      field1: { a: 1, b: 2 },
+      field2: { c: 3, d: 4 },
+    };
+    const fields = ['field1', 'field2'];
+    const output = stringifyJsonFields(input, fields);
+
+    expect(output.field1).toBe(
+      JSON.stringify({ a: 1, b: 2 }, replaceNullWithEmptyString),
+    );
+    expect(output.field2).toBe(
+      JSON.stringify({ c: 3, d: 4 }, replaceNullWithEmptyString),
+    );
+  });
+
+  it('should not change fields that are not specified', () => {
+    const input = {
+      field1: { a: 1, b: 2 },
+      field2: { c: 3, d: 4 },
+      field3: { e: 5, f: 6 },
+    };
+    const fields = ['field1'];
+    const output = stringifyJsonFields(input, fields);
+
+    expect(output.field1).toBe(
+      JSON.stringify({ a: 1, b: 2 }, replaceNullWithEmptyString),
+    );
+    expect(output.field2).toEqual({ c: 3, d: 4 });
+    expect(output.field3).toEqual({ e: 5, f: 6 });
+  });
+
+  it('should handle fields with null values correctly', () => {
+    const input = {
+      field1: { a: 1, b: null },
+    };
+    const fields = ['field1'];
+    const output = stringifyJsonFields(input, fields);
+
+    expect(output.field1).toBe(
+      JSON.stringify({ a: 1, b: '' }, replaceNullWithEmptyString),
+    );
+  });
+
+  it('should not modify the input object if no fields are specified', () => {
+    const input = {
+      field1: { a: 1, b: 2 },
+    };
+    const output = stringifyJsonFields(input, []);
+
+    expect(output).toEqual(input);
+  });
+
+  it('should not modify the input object if specified fields do not exist', () => {
+    const input = {
+      field1: { a: 1, b: 2 },
+    };
+    const fields = ['field2'];
+    const output = stringifyJsonFields(input, fields);
+
+    expect(output).toEqual(input);
   });
 });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 /**
  * Adds or merges specified parameters into a URLSearchParams object.
  *
@@ -157,23 +159,19 @@ export const replaceNullWithEmptyString = (_: any, value: any) =>
   value === null ? '' : value;
 
 /*
- * Stringifies all JSON field values within the asset.attribute object
+ * Stringifies all JSON field values in the specified fields array.
  */
 export const stringifyJsonFields = (
   object: Record<string, any>,
   fields: string[] = [],
 ): Record<string, any> => {
-  const normalizedObject = { ...object };
+  const modifiedObject = { ...object };
 
   for (const field of fields) {
-    if (!normalizedObject[field]) {
-      continue;
-    }
-    normalizedObject[field] = JSON.stringify(
-      normalizedObject[field],
-      replaceNullWithEmptyString,
-    );
+    const value = _.get(object, field);
+    const newValue = JSON.stringify(value, replaceNullWithEmptyString);
+    _.set(modifiedObject, field, newValue);
   }
 
-  return normalizedObject;
+  return modifiedObject;
 };

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -149,3 +149,31 @@ export const paramsReducer = (
       return removeParams(existingParams, newParams);
   }
 };
+
+/**
+ * Stringifies value to '' if the value is null
+ */
+export const replaceNullWithEmptyString = (_: any, value: any) =>
+  value === null ? '' : value;
+
+/*
+ * Stringifies all JSON field values within the asset.attribute object
+ */
+export const stringifyJsonFields = (
+  object: Record<string, any>,
+  fields: string[] = [],
+): Record<string, any> => {
+  const normalizedObject = { ...object };
+
+  for (const field of fields) {
+    if (!normalizedObject[field]) {
+      continue;
+    }
+    normalizedObject[field] = JSON.stringify(
+      normalizedObject[field],
+      replaceNullWithEmptyString,
+    );
+  }
+
+  return normalizedObject;
+};


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

- Move `stringifyJSONFields` to a helper directory for re-use
- Adds width & height metadata to images on select.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
Some images did not have width and height information available once selected.

<!-- After this PR... -->
## After
All images, after selection, will include metadata. Specifically, width and height information.

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Steps to test
1. Select an image using the staging deployment of the plugin
2. Make a request for a the Contentful Entry ID of the entry you just edited
3. You should see this is the Contentful API response for the image

```js
"attributes": { 
  // … 👇attributes from the `fm=json`request included in the asset.attributes
  "media_width": 5773,
  "media_height": 8660,
}
```
## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
