### PR TITLE
feat: add default sourceID configuration fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ npm run start
 
 Upon installation, configure the app using an API key generated via the imgix [Dashboard](https://dashboard.imgix.com/api-keys). **Ensure that the generated key has the following permissions: `Sources` and `Asset Manager Browse`.**
 
+> [!TIP]
+> You can also optionally configure a default Source ID for the app to use. When configured, you'll have to click the Sources dropdown to select an asset from a different source.
+
 Following the instructions on the screen, enter in the API key and press `Verify`. If the key is valid, you will receive a notification that the key has been successfully verified. If verification fails, you will need to ensure that the key was entered correctly.
 
 <!-- ix-docs-ignore -->
@@ -382,4 +385,3 @@ export const query = graphql`
   }
 `;
 ```
-

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -6,7 +6,6 @@ import {
   Workbench,
   Paragraph,
   TextField,
-  Notification,
   Icon,
   TextLink,
   List,

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -23,6 +23,7 @@ import packageJson from './../../../package.json';
 
 export interface AppInstallationParameters {
   imgixAPIKey?: string;
+  sourceID?: string;
   successfullyVerified?: boolean;
 }
 
@@ -197,10 +198,27 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     return { ...currentState, EditorInterface };
   };
 
-  handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  handleAPIKeyChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const prevState = { ...this.state };
     this.setState({
       parameters: {
+        ...prevState.parameters,
         imgixAPIKey: e.target.value,
+        successfullyVerified: this.state.parameters.successfullyVerified,
+      },
+    });
+  };
+
+  handleSourceIDChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const prevState = { ...this.state };
+    this.setState({
+      parameters: {
+        ...prevState.parameters,
+        sourceID: e.target.value,
         successfullyVerified: this.state.parameters.successfullyVerified,
       },
     });
@@ -219,7 +237,12 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     };
 
     try {
-      await imgix.request('sources');
+      if (this.state.parameters.sourceID?.length) {
+        await imgix.request(`sources/${this.state.parameters.sourceID}`);
+      } else {
+        await imgix.request('sources');
+      }
+
       Notification.setPosition('top', { offset: 650 });
       Notification.success(
         'Your API key was successfully confirmed! Click the Install/Save button (in the top right corner) to complete installation.',
@@ -347,7 +370,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                     type: 'password',
                     autoComplete: 'new-api-key',
                   }}
-                  onChange={this.handleChange}
+                  onChange={this.handleAPIKeyChange}
                 />
               </div>
               {this.state.parameters.successfullyVerified && (
@@ -366,6 +389,22 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                 https://dashboard.imgix.com/api-keys
               </a>
             </p>
+            <div className="flex-container">
+              <div className="flex-child">
+                <TextField
+                  name="Default Source"
+                  id="SourceID"
+                  labelText="Default Source ID"
+                  value={this.state.parameters?.sourceID || ''}
+                  validationMessage={this.state.validationMessage}
+                  textInputProps={{
+                    type: 'text',
+                    autoComplete: 'default-source-id',
+                  }}
+                  onChange={this.handleSourceIDChange}
+                />
+              </div>
+            </div>
           </div>
           <Button
             type="submit"

--- a/src/components/ConfigScreen/ConfigScreen.tsx
+++ b/src/components/ConfigScreen/ConfigScreen.tsx
@@ -385,7 +385,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
                 <TextField
                   name="Default Source"
                   id="SourceID"
-                  labelText="Default Source ID"
+                  labelText="Default Source ID (Optional) "
                   value={this.state.parameters?.sourceID || ''}
                   textInputProps={{
                     type: 'text',

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -257,12 +257,12 @@ export default class Dialog extends Component<DialogProps, DialogState> {
 
       // check if previously selected source exists
       // if it does, add it to state.
-      const previouslySelectedSource =
+      const previouslySelectedSourceID =
         invocationParams?.selectedImage?.selectedSource?.id ||
         installationParams.sourceID;
 
       const selectedSource = sources.find((source: any) => {
-        return source.id === previouslySelectedSource;
+        return source.id === previouslySelectedSourceID;
       });
 
       if (selectedSource) {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -250,15 +250,21 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       if (sources.length === 0) {
         throw noSourcesError();
       }
+      const invocationParams = this.props.sdk.parameters
+        .invocation as AppInvocationParameters;
+      const installationParams = this.props.sdk.parameters
+        .installation as AppInstallationParameters;
+
       // check if previously selected source exists
       // if it does, add it to state.
-      const previouslySelectedSource = (
-        this.props.sdk.parameters.invocation as AppInvocationParameters
-      )?.selectedImage?.selectedSource;
+      const previouslySelectedSource =
+        invocationParams?.selectedImage?.selectedSource?.id ||
+        installationParams.sourceID;
 
       const selectedSource = sources.find((source: any) => {
-        return source.id === previouslySelectedSource?.id;
+        return source.id === previouslySelectedSource;
       });
+
       if (selectedSource) {
         this.setState({ allSources: sources, selectedSource });
       } else {

--- a/src/components/Gallery/ImageGallery.tsx
+++ b/src/components/Gallery/ImageGallery.tsx
@@ -108,7 +108,12 @@ export class Gallery extends Component<GalleryProps, GalleryState> {
         <GalleryPlaceholder
           sdk={this.props.sdk}
           handleClose={this.handleClose}
-          text="Select a Source to view your image gallery"
+          text={
+            // @ts-ignore
+            this.props.sdk.parameters.installation.sourceID
+              ? 'Loading'
+              : 'Select a Source to view your image gallery'
+          }
         />
       ) : // If the source is a webfolder
       this.props.selectedSource.type === 'webfolder' ? (

--- a/src/components/SourceSelect/SourceSelectDropdown.tsx
+++ b/src/components/SourceSelect/SourceSelectDropdown.tsx
@@ -5,7 +5,6 @@ import {
   Dropdown,
   DropdownList,
   DropdownListItem,
-  Paragraph,
   Spinner,
 } from '@contentful/forma-36-react-components';
 
@@ -42,24 +41,30 @@ export function SourceSelectDropdown({
       isOpen={isOpen}
       onClose={() => setOpen(false)}
       toggleElement={
-        <Button
-          size="small"
-          buttonType="muted"
-          className="ix-dropdown"
-          indicateDropdown
-          onClick={() => setOpen(!isOpen)}
-          disabled={disabled}
-        >
-          {selectedSource.name || 'Select an imgix Source'}
-        </Button>
+        !allSources.length ? (
+          <Button
+            size="small"
+            buttonType="muted"
+            className="ix-dropdown"
+            disabled={true}
+          >
+            <Spinner />
+          </Button>
+        ) : (
+          <Button
+            size="small"
+            buttonType="muted"
+            className="ix-dropdown"
+            indicateDropdown
+            onClick={() => setOpen(!isOpen)}
+            disabled={disabled}
+          >
+            {selectedSource.name || 'Select an imgix Source'}
+          </Button>
+        )
       }
     >
       <DropdownList className="ix-dropdown-list">
-        {!allSources.length ? (
-          <Paragraph style={{ paddingLeft: 5 }}>
-            Loading <Spinner />
-          </Paragraph>
-        ) : null}
         {allSources.map((source: SourceProps) => (
           <DropdownListItem key={source.id} onClick={() => handleClick(source)}>
             {source.name}


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

- Adds a configuration field for a default source ID
- Updates sources dropdown button to show loading while fetching sources
- Defaults the Dialog to the configured source ID if set, otherwise fetches sources list

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
- No way to configure a default source
- Loading indicator on sources dropdown was only shown when clicking dropdown
- Hitting "save" with an invalid configuration would persist the changes despite showing a warning or error

<!-- After this PR... -->
## After
- Customers can configure a default source
- Loading indicator for sources dropdown visible without clicking
- Trying to save an invalid configuration does not persist the changes

Loading indicator

https://github.com/imgix/contentful/assets/16711614/1efa824b-6a0e-4517-b287-2937a350e33b

Default source

https://github.com/imgix/contentful/assets/16711614/2bf68751-e699-42ba-8eff-b56b49664948

API KEY Validation
>NOTE: the source ID is hidden in the video but _not_ when you clone or preview this branch. This is on purpose. I'm only hiding the source ID on the video out of extreme caution.

https://github.com/imgix/contentful/assets/16711614/977ac85f-4c7f-466d-9b69-b63274948076




<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->
## Steps to test
1. Clone, `npm install`, and `pnpm run start`
2. Go to Contentful development space
3. Opent the content with the `localhost` field
4. Remove any previously selected image
5. Refresh the page
6. To go `Apps --> Installed Apps --> imgix development --> configure`
7. Add the sourceID of your choosing as the default sourceID
8. See that API key validation succeeds/fails if associated/not associated with said source
9. Go back to the previous content entry
10. Add an image
11. See that the modal defaults to the configured source ID

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
